### PR TITLE
Fix converting single line JSDoc comment to ESTree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+/.idea

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,17 @@
 
 ### User-impacting
 
+- feat: add non-visitable `endLine` property (so can detect line number
+    when no description present)
 - feat: supply `indent` default for `parseComment`
 - fix: ensure `postName` gets a space for `@template` with a description
+- fix: converting JSDoc comment with tag on same line as end (e.g., single
+    line) to AST
 - chore: update `jsdoc-type-pratt-parser`
 
 ### Dev-impacting
 
+- docs: add jsdoc blocks internally
 - chore: update devDeps.
 - test: avoid need for `expect`
 - test: complete coverage for `commentHandler`, `parseComment` tests

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Has two visitable properties:
 Has the following custom non-visitable property:
 
 1. `lastDescriptionLine` - A number
+2. `endLine` - A number representing the line number with `end`
 
 May also have the following non-visitable properties from `comment-parser`:
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ May also have the following non-visitable properties from `comment-parser`:
 1. `description` - Same as `descriptionLines` but as a string with newlines.
 2. `delimiter`
 3. `postDelimiter`
-4. `end`
+4. `lineEnd`
+5. `end`
 
 ### `JsdocTag`
 

--- a/dist/index.cjs.cjs
+++ b/dist/index.cjs.cjs
@@ -10,6 +10,13 @@ function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'defau
 
 var esquery__default = /*#__PURE__*/_interopDefaultLegacy(esquery);
 
+/**
+ * Removes initial and ending brackets from `rawType`
+ * @param {JsdocTypeLine[]|JsdocTag} container
+ * @param {boolean} isArr
+ * @returns {void}
+ */
+
 const stripEncapsulatingBrackets = (container, isArr) => {
   if (isArr) {
     const firstItem = container[0];
@@ -21,6 +28,13 @@ const stripEncapsulatingBrackets = (container, isArr) => {
 
   container.rawType = container.rawType.replace(/^\{/u, '').replace(/\}$/u, '');
 };
+/**
+ * Strips brackets from a tag's `rawType` values and adds `parsedType`
+ * @param {JsdocTag} lastTag
+ * @param {external:JsdocTypePrattParserMode} mode
+ * @returns {void}
+ */
+
 
 const cleanUpLastTag = (lastTag, mode) => {
   // Strip out `}` that encapsulates and is not part of
@@ -41,6 +55,71 @@ const cleanUpLastTag = (lastTag, mode) => {
 
   lastTag.parsedType = parsedType;
 };
+/**
+ * @external CommentParserJsdoc
+ */
+
+/**
+ * @external JsdocTypePrattParserMode
+ */
+
+/**
+ * @typedef {{
+ *   delimiter: string,
+ *   postDelimiter: string,
+ *   rawType: string,
+ *   start: string,
+ *   type: "JsdocTypeLine"
+ * }} JsdocTypeLine
+ */
+
+/**
+ * @typedef {{
+ *   delimiter: string,
+ *   description: string,
+ *   postDelimiter: string,
+ *   start: string,
+ *   type: "JsdocDescriptionLine"
+ * }} JsdocDescriptionLine
+ */
+
+/**
+ * @typedef {{
+ *   delimiter: string,
+ *   description: string,
+ *   postDelimiter: string,
+ *   start: string,
+ *   tag: string,
+ *   end: string,
+ *   type: string,
+ *   descriptionLines: JsdocDescriptionLine[],
+ *   rawType: string,
+ *   type: "JsdocTag",
+ *   typeLines: JsdocTypeLine[]
+ * }} JsdocTag
+ */
+
+/**
+ * @typedef {{
+ *   delimiter: string,
+ *   description: string,
+ *   descriptionLines: JsdocDescriptionLine[],
+ *   end: string,
+ *   postDelimiter: string,
+ *   lineEnd: string,
+ *   type: "JsdocBlock",
+ *   lastDescriptionLine: Integer,
+ *   tags: JsdocTag[]
+ * }} JsdocBlock
+ */
+
+/**
+ *
+ * @param {external:CommentParserJsdoc} jsdoc
+ * @param {external:JsdocTypePrattParserMode} mode
+ * @returns {JsdocBlock}
+ */
+
 
 const commentParserToESTree = (jsdoc, mode) => {
   const {

--- a/src/commentParserToESTree.js
+++ b/src/commentParserToESTree.js
@@ -1,5 +1,11 @@
 import {parse as jsdocTypePrattParse} from 'jsdoc-type-pratt-parser';
 
+/**
+ * Removes initial and ending brackets from `rawType`
+ * @param {JsdocTypeLine[]|JsdocTag} container
+ * @param {boolean} isArr
+ * @returns {void}
+ */
 const stripEncapsulatingBrackets = (container, isArr) => {
   if (isArr) {
     const firstItem = container[0];
@@ -17,6 +23,12 @@ const stripEncapsulatingBrackets = (container, isArr) => {
   ).replace(/\}$/u, '');
 };
 
+/**
+ * Strips brackets from a tag's `rawType` values and adds `parsedType`
+ * @param {JsdocTag} lastTag
+ * @param {external:JsdocTypePrattParserMode} mode
+ * @returns {void}
+ */
 const cleanUpLastTag = (lastTag, mode) => {
   // Strip out `}` that encapsulates and is not part of
   //   the type
@@ -36,6 +48,70 @@ const cleanUpLastTag = (lastTag, mode) => {
   lastTag.parsedType = parsedType;
 };
 
+/**
+ * @external CommentParserJsdoc
+ */
+
+/**
+ * @external JsdocTypePrattParserMode
+ */
+
+/**
+ * @typedef {{
+ *   delimiter: string,
+ *   postDelimiter: string,
+ *   rawType: string,
+ *   start: string,
+ *   type: "JsdocTypeLine"
+ * }} JsdocTypeLine
+ */
+
+/**
+ * @typedef {{
+ *   delimiter: string,
+ *   description: string,
+ *   postDelimiter: string,
+ *   start: string,
+ *   type: "JsdocDescriptionLine"
+ * }} JsdocDescriptionLine
+ */
+
+/**
+ * @typedef {{
+ *   delimiter: string,
+ *   description: string,
+ *   postDelimiter: string,
+ *   start: string,
+ *   tag: string,
+ *   end: string,
+ *   type: string,
+ *   descriptionLines: JsdocDescriptionLine[],
+ *   rawType: string,
+ *   type: "JsdocTag",
+ *   typeLines: JsdocTypeLine[]
+ * }} JsdocTag
+ */
+
+/**
+ * @typedef {{
+ *   delimiter: string,
+ *   description: string,
+ *   descriptionLines: JsdocDescriptionLine[],
+ *   end: string,
+ *   postDelimiter: string,
+ *   lineEnd: string,
+ *   type: "JsdocBlock",
+ *   lastDescriptionLine: Integer,
+ *   tags: JsdocTag[]
+ * }} JsdocBlock
+ */
+
+/**
+ *
+ * @param {external:CommentParserJsdoc} jsdoc
+ * @param {external:JsdocTypePrattParserMode} mode
+ * @returns {JsdocBlock}
+ */
 const commentParserToESTree = (jsdoc, mode) => {
   const {source} = jsdoc;
 

--- a/test/commentParserToESTree.js
+++ b/test/commentParserToESTree.js
@@ -1,0 +1,100 @@
+import {expect} from 'chai';
+
+import {commentParserToESTree} from '../src/commentParserToESTree.js';
+import {parseComment} from '../src/parseComment.js';
+
+describe('commentParserToESTree', function () {
+  it('handles single line jsdoc comment with tag', () => {
+    const parsedComment = parseComment({
+      value: `* @type {string} `
+    });
+
+    const ast = commentParserToESTree(parsedComment, 'javascript');
+
+    expect(ast).to.deep.equal({
+      type: 'JsdocBlock',
+      delimiter: '/**',
+      description: '',
+      descriptionLines: [],
+      end: '*/',
+      lastDescriptionLine: 0,
+      lineEnd: '',
+      postDelimiter: ' ',
+      tags: [
+        {
+          delimiter: '/**',
+          description: '',
+          descriptionLines: [],
+          lineEnd: '',
+          name: '',
+          parsedType: null,
+          postDelimiter: ' ',
+          postName: '',
+          postTag: ' ',
+          postType: ' ',
+          tag: 'type',
+          type: 'JsdocTag',
+          rawType: 'string',
+          start: '',
+          typeLines: [
+            {
+              delimiter: '/**',
+              postDelimiter: ' ',
+              rawType: 'string',
+              start: '',
+              type: 'JsdocTypeLine'
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('handles multi line jsdoc comment with tag', () => {
+    const parsedComment = parseComment({
+      value: '*\n' +
+      ' * @type {string}\n' +
+      ' *'
+    });
+
+    const ast = commentParserToESTree(parsedComment, 'javascript');
+
+    expect(ast).to.deep.equal({
+      type: 'JsdocBlock',
+      delimiter: '/**',
+      description: '',
+      descriptionLines: [],
+      end: '*/',
+      lastDescriptionLine: 0,
+      lineEnd: '',
+      postDelimiter: '',
+      tags: [
+        {
+          delimiter: '*',
+          description: '',
+          descriptionLines: [],
+          lineEnd: '',
+          name: '',
+          parsedType: null,
+          postDelimiter: ' ',
+          postName: '',
+          postTag: ' ',
+          postType: '',
+          tag: 'type',
+          type: 'JsdocTag',
+          rawType: 'string',
+          start: ' ',
+          typeLines: [
+            {
+              delimiter: '*',
+              postDelimiter: ' ',
+              rawType: 'string',
+              start: ' ',
+              type: 'JsdocTypeLine'
+            }
+          ]
+        }
+      ]
+    });
+  });
+});

--- a/test/commentParserToESTree.js
+++ b/test/commentParserToESTree.js
@@ -1,5 +1,3 @@
-import {expect} from 'chai';
-
 import {commentParserToESTree} from '../src/commentParserToESTree.js';
 import {parseComment} from '../src/parseComment.js';
 
@@ -17,6 +15,7 @@ describe('commentParserToESTree', function () {
       description: '',
       descriptionLines: [],
       end: '*/',
+      endLine: 0,
       lastDescriptionLine: 0,
       lineEnd: '',
       postDelimiter: ' ',
@@ -50,11 +49,10 @@ describe('commentParserToESTree', function () {
     });
   });
 
-  it('handles multi line jsdoc comment with tag', () => {
+  it('handles multi line jsdoc comment beginning on line 0', () => {
     const parsedComment = parseComment({
-      value: '*\n' +
-      ' * @type {string}\n' +
-      ' *'
+      value: `* @type {string}
+`
     });
 
     const ast = commentParserToESTree(parsedComment, 'javascript');
@@ -65,7 +63,56 @@ describe('commentParserToESTree', function () {
       description: '',
       descriptionLines: [],
       end: '*/',
+      endLine: 1,
       lastDescriptionLine: 0,
+      lineEnd: '',
+      postDelimiter: ' ',
+      tags: [
+        {
+          delimiter: '/**',
+          description: '',
+          descriptionLines: [],
+          lineEnd: '',
+          name: '',
+          parsedType: null,
+          postDelimiter: ' ',
+          postName: '',
+          postTag: ' ',
+          postType: '',
+          tag: 'type',
+          type: 'JsdocTag',
+          rawType: 'string',
+          start: '',
+          typeLines: [
+            {
+              delimiter: '/**',
+              postDelimiter: ' ',
+              rawType: 'string',
+              start: '',
+              type: 'JsdocTypeLine'
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('handles multi line jsdoc comment ending on line 1', () => {
+    const parsedComment = parseComment({
+      value: `*
+ * @type {string}`
+    });
+
+    const ast = commentParserToESTree(parsedComment, 'javascript');
+
+    expect(ast).to.deep.equal({
+      type: 'JsdocBlock',
+      delimiter: '/**',
+      description: '',
+      descriptionLines: [],
+      end: '*/',
+      endLine: 1,
+      lastDescriptionLine: 1,
       lineEnd: '',
       postDelimiter: '',
       tags: [
@@ -97,4 +144,172 @@ describe('commentParserToESTree', function () {
       ]
     });
   });
+
+  it('handles multi line jsdoc comment with tag', () => {
+    const parsedComment = parseComment({
+      value: `*
+ * @type {string}
+ *`
+    });
+
+    const ast = commentParserToESTree(parsedComment, 'javascript');
+
+    expect(ast).to.deep.equal({
+      type: 'JsdocBlock',
+      delimiter: '/**',
+      description: '',
+      descriptionLines: [],
+      end: '*/',
+      endLine: 2,
+      lastDescriptionLine: 1,
+      lineEnd: '',
+      postDelimiter: '',
+      tags: [
+        {
+          delimiter: '*',
+          description: '',
+          descriptionLines: [],
+          lineEnd: '',
+          name: '',
+          parsedType: null,
+          postDelimiter: ' ',
+          postName: '',
+          postTag: ' ',
+          postType: '',
+          tag: 'type',
+          type: 'JsdocTag',
+          rawType: 'string',
+          start: ' ',
+          typeLines: [
+            {
+              delimiter: '*',
+              postDelimiter: ' ',
+              rawType: 'string',
+              start: ' ',
+              type: 'JsdocTypeLine'
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+  it(
+    'handles multi line jsdoc comment with tag and multiline description',
+    () => {
+      const parsedComment = parseComment({
+        value: `*
+ * @param {string} Some
+ * multi-line
+ description
+ *`
+      });
+
+      const ast = commentParserToESTree(parsedComment, 'javascript');
+
+      expect(ast).to.deep.equal({
+        type: 'JsdocBlock',
+        delimiter: '/**',
+        description: '',
+        descriptionLines: [],
+        end: '*/',
+        endLine: 4,
+        lastDescriptionLine: 1,
+        lineEnd: '',
+        postDelimiter: '',
+        tags: [
+          {
+            delimiter: '*',
+            description: 'multi-line\ndescription',
+            descriptionLines: [
+              {
+                delimiter: '*',
+                description: 'multi-line',
+                postDelimiter: ' ',
+                start: ' ',
+                type: 'JsdocDescriptionLine'
+              },
+              {
+                delimiter: '',
+                description: 'description',
+                postDelimiter: '',
+                start: ' ',
+                type: 'JsdocDescriptionLine'
+              }
+            ],
+            lineEnd: '',
+            name: 'Some',
+            parsedType: null,
+            postDelimiter: ' ',
+            postName: '',
+            postTag: ' ',
+            postType: ' ',
+            tag: 'param',
+            type: 'JsdocTag',
+            rawType: 'string',
+            start: ' ',
+            typeLines: [
+              {
+                delimiter: '*',
+                postDelimiter: ' ',
+                rawType: 'string',
+                start: ' ',
+                type: 'JsdocTypeLine'
+              }
+            ]
+          }
+        ]
+      });
+    }
+  );
+
+  it(
+    'handles multi line jsdoc comment with multiline description',
+    () => {
+      const parsedComment = parseComment({
+        value: `*
+ * Some
+ * multi-line
+ description
+ *`
+      });
+
+      const ast = commentParserToESTree(parsedComment, 'javascript');
+
+      expect(ast).to.deep.equal({
+        type: 'JsdocBlock',
+        delimiter: '/**',
+        description: 'Some\nmulti-line\ndescription',
+        descriptionLines: [
+          {
+            delimiter: '*',
+            description: 'Some',
+            postDelimiter: ' ',
+            start: ' ',
+            type: 'JsdocDescriptionLine'
+          },
+          {
+            delimiter: '*',
+            description: 'multi-line',
+            postDelimiter: ' ',
+            start: ' ',
+            type: 'JsdocDescriptionLine'
+          },
+          {
+            delimiter: '',
+            description: 'description',
+            postDelimiter: '',
+            start: ' ',
+            type: 'JsdocDescriptionLine'
+          }
+        ],
+        end: '*/',
+        endLine: 4,
+        lastDescriptionLine: 4,
+        lineEnd: '',
+        postDelimiter: '',
+        tags: []
+      });
+    }
+  );
 });


### PR DESCRIPTION
This is a proposal for a fix of the issue related to the issue in https://github.com/gajus/eslint-plugin-jsdoc/issues/831 `eslint-plugin-jsdoc` project.

The `commentParserToESTree` doesn't support a single line JSDoc comments. I was trying to fix that and add missing unit tests.