### PR TITLE
build: add Node 18 support

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,6 +16,7 @@ jobs:
           - 14.x
           - 16.x
           - 17.x
+          - 18.x
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/es-joy/jsdoccomment",
   "engines": {
-    "node": "^12 || ^14 || ^16 || ^17"
+    "node": "^12 || ^14 || ^16 || ^17 || ^18"
   },
   "dependencies": {
     "comment-parser": "1.3.1",


### PR DESCRIPTION
Node 18 is out. This adds it to the CI and package.json.