### PR TITLE
Support node 19

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,6 +17,7 @@ jobs:
           - 16.x
           - 17.x
           - 18.x
+          - 19.x
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/es-joy/jsdoccomment",
   "engines": {
-    "node": "^14 || ^16 || ^17 || ^18"
+    "node": "^14 || ^16 || ^17 || ^18 || ^19"
   },
   "dependencies": {
     "comment-parser": "1.3.1",


### PR DESCRIPTION
## Motivation
Support node 19 now that it has been officially released by node, see:
* https://nodejs.org/en/download/current/
* https://github.com/nodejs/Release#release-schedule

## Current behavior
When trying to install dependencies `yarn` fails with the following error:
```
error @es-joy/jsdoccomment@0.32.0: The engine "node" is incompatible with this module. Expected version "^14 || ^16 || ^17 || ^18". Got "19.0.0"
```

## Desired behavior
Installing `@es-joy/jsdoccomment` when using node 19 should work.

## Alternatives considered
We could use something like `yarn install --ignore-engines` as a workaround but that opens us up to compatibility errors that will only show up at runtime.
