### PR TITLE
feat: add parsing inline tags

### DIFF
--- a/dist/index.cjs.cjs
+++ b/dist/index.cjs.cjs
@@ -382,7 +382,7 @@ function parseDescription(description) {
   // The pattern used to match for text after tag uses a negative lookbehind
   // on the ']' char to avoid matching the prefixed case too.
   // eslint-disable-next-line prefer-regex-literals -- Need 'd' (indices) flag
-  const suffixedAfterPattern = new RegExp(/(?<!\])\{@(?<tag>[^}\s]+)\s?(?<namepathOrURL>[^}\s|]*)(?<separator>[\s|])?(?<text>[^}]*)\}/gu, 'gud');
+  const suffixedAfterPattern = new RegExp(/(?<!\])\{@(?<tag>[^}\s]+)\s?(?<namepathOrURL>[^}\s|]*)\s*(?<separator>[\s|])?\s*(?<text>[^}]*)\}/gu, 'gud');
   const matches = [...description.matchAll(prefixedTextPattern), ...description.matchAll(suffixedAfterPattern)];
   for (const match of matches) {
     const {

--- a/dist/index.cjs.cjs
+++ b/dist/index.cjs.cjs
@@ -349,7 +349,7 @@ const toCamelCase = str => {
  * @param {RegExpMatchArray} match An inline tag regexp match.
  * @returns {string}
  */
-function determineTextStyle(match) {
+function determineFormat(match) {
   const {
     separator,
     text
@@ -391,12 +391,12 @@ function parseDescription(description) {
       text
     } = match.groups;
     const [start, end] = match.indices[0];
-    const textStyle = determineTextStyle(match);
+    const format = determineFormat(match);
     result.push({
       tag,
       namepathOrURL,
       text,
-      textStyle,
+      format,
       start,
       end
     });

--- a/src/parseComment.js
+++ b/src/parseComment.js
@@ -4,6 +4,8 @@ import {
   tokenizers
 } from 'comment-parser';
 
+import parseInlineTags from './parseInlineTags.js';
+
 const {
   name: nameTokenizer,
   tag: tagTokenizer,
@@ -111,10 +113,11 @@ const getTokenizers = ({
  */
 const parseComment = (commentNode, indent = '') => {
   // Preserve JSDoc block start/end indentation.
-  return commentParser(`${indent}/*${commentNode.value}*/`, {
+  const [block] = commentParser(`${indent}/*${commentNode.value}*/`, {
     // @see https://github.com/yavorskiy/comment-parser/issues/21
     tokenizers: getTokenizers()
-  })[0];
+  });
+  return parseInlineTags(block);
 };
 
 export {getTokenizers, parseComment};

--- a/src/parseInlineTags.js
+++ b/src/parseInlineTags.js
@@ -33,7 +33,7 @@ function parseDescription (description) {
   // The pattern used to match for text after tag uses a negative lookbehind
   // on the ']' char to avoid matching the prefixed case too.
   // eslint-disable-next-line prefer-regex-literals -- Need 'd' (indices) flag
-  const suffixedAfterPattern = new RegExp(/(?<!\])\{@(?<tag>[^}\s]+)\s?(?<namepathOrURL>[^}\s|]*)(?<separator>[\s|])?(?<text>[^}]*)\}/gu, 'gud');
+  const suffixedAfterPattern = new RegExp(/(?<!\])\{@(?<tag>[^}\s]+)\s?(?<namepathOrURL>[^}\s|]*)\s*(?<separator>[\s|])?\s*(?<text>[^}]*)\}/gu, 'gud');
 
   const matches = [
     ...description.matchAll(prefixedTextPattern),

--- a/src/parseInlineTags.js
+++ b/src/parseInlineTags.js
@@ -1,0 +1,72 @@
+
+/**
+ * @param {RegExpMatchArray} match An inline tag regexp match.
+ * @returns {string}
+ */
+function determineTextStyle (match) {
+  const {separator, text} = match.groups;
+  const [, textEnd] = match.indices.groups.text;
+  const [tagStart] = match.indices.groups.tag;
+  if (!text) {
+    return 'plain';
+  } else if (separator === '|') {
+    return 'pipe';
+  } else if (textEnd < tagStart) {
+    return 'prefix';
+  }
+  return 'space';
+}
+
+/**
+ * Extracts inline tags from a description.
+ * @param {string} description
+ * @returns {InlineTag[]} Array of inline tags from the description.
+ */
+function parseDescription (description) {
+  const result = [];
+
+  // This could have been expressed in a single pattern,
+  // but having two avoids a potentially exponential time regex.
+
+  // eslint-disable-next-line prefer-regex-literals -- Need 'd' (indices) flag
+  const prefixedTextPattern = new RegExp(/(?:\[(?<text>[^\]]+)\])\{@(?<tag>[^}\s]+)\s?(?<namepathOrURL>[^}\s|]*)\}/gu, 'gud');
+  // The pattern used to match for text after tag uses a negative lookbehind
+  // on the ']' char to avoid matching the prefixed case too.
+  // eslint-disable-next-line prefer-regex-literals -- Need 'd' (indices) flag
+  const suffixedAfterPattern = new RegExp(/(?<!\])\{@(?<tag>[^}\s]+)\s?(?<namepathOrURL>[^}\s|]*)(?<separator>[\s|])?(?<text>[^}]*)\}/gu, 'gud');
+
+  const matches = [
+    ...description.matchAll(prefixedTextPattern),
+    ...description.matchAll(suffixedAfterPattern)
+  ];
+
+  for (const match of matches) {
+    const {tag, namepathOrURL, text} = match.groups;
+    const [start, end] = match.indices[0];
+    const textStyle = determineTextStyle(match);
+
+    result.push({
+      tag,
+      namepathOrURL,
+      text,
+      textStyle,
+      start,
+      end
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Splits the `{@prefix}` from remaining `Spec.lines[].token.description`
+ * into the `inlineTags` tokens, and populates `spec.inlineTags`
+ * @param {Block} block
+ */
+export default function parseInlineTags (block) {
+  block.inlineTags = parseDescription(block.description);
+  for (const tag of block.tags) {
+    tag.inlineTags = parseDescription(tag.description);
+  }
+  return block;
+}

--- a/src/parseInlineTags.js
+++ b/src/parseInlineTags.js
@@ -3,7 +3,7 @@
  * @param {RegExpMatchArray} match An inline tag regexp match.
  * @returns {string}
  */
-function determineTextStyle (match) {
+function determineFormat (match) {
   const {separator, text} = match.groups;
   const [, textEnd] = match.indices.groups.text;
   const [tagStart] = match.indices.groups.tag;
@@ -43,13 +43,13 @@ function parseDescription (description) {
   for (const match of matches) {
     const {tag, namepathOrURL, text} = match.groups;
     const [start, end] = match.indices[0];
-    const textStyle = determineTextStyle(match);
+    const format = determineFormat(match);
 
     result.push({
       tag,
       namepathOrURL,
       text,
-      textStyle,
+      format,
       start,
       end
     });

--- a/test/commentParserToESTree.js
+++ b/test/commentParserToESTree.js
@@ -41,9 +41,11 @@ const singleLineWithTag = {
           initial: '',
           type: 'JsdocTypeLine'
         }
-      ]
+      ],
+      inlineTags: []
     }
-  ]
+  ],
+  inlineTags: []
 };
 
 const singleLineWithMultilineTag = {
@@ -101,10 +103,109 @@ const singleLineWithMultilineTag = {
           initial: '',
           type: 'JsdocTypeLine'
         }
-      ]
+      ],
+      inlineTags: []
+    }
+  ],
+  inlineTags: []
+};
+
+const singleLineWithInlineTag = ({
+  description,
+  format,
+  namepathOrURL,
+  tag,
+  text
+}) => ({
+  type: 'JsdocBlock',
+  delimiter: '/**',
+  description,
+  descriptionLines: [
+    {
+      delimiter: '/**',
+      description,
+      initial: '',
+      postDelimiter: ' ',
+      type: 'JsdocDescriptionLine'
+    }
+  ],
+  descriptionStartLine: 0,
+  descriptionEndLine: 0,
+  initial: '',
+  terminal: '*/',
+  endLine: 0,
+  hasPreterminalDescription: 1,
+  lastDescriptionLine: 0,
+  lineEnd: '',
+  postDelimiter: ' ',
+  tags: [],
+  inlineTags: [
+    {
+      format,
+      namepathOrURL,
+      tag,
+      text,
+      type: 'JsdocInlineTag'
     }
   ]
-};
+});
+
+const singleTagWithInlineTag = ({
+  format,
+  namepathOrURL,
+  tag,
+  text
+}) => ({
+  type: 'JsdocBlock',
+  delimiter: '/**',
+  description: '',
+  descriptionLines: [],
+  initial: '',
+  terminal: '*/',
+  endLine: 0,
+  hasPreterminalDescription: 0,
+  hasPreterminalTagDescription: 1,
+  lastDescriptionLine: 0,
+  lineEnd: '',
+  postDelimiter: ' ',
+  tags: [
+    {
+      delimiter: '',
+      description: 'This is {@link Something}',
+      descriptionLines: [
+        {
+          delimiter: '',
+          description: 'This is {@link Something}',
+          initial: '',
+          postDelimiter: '',
+          type: 'JsdocDescriptionLine'
+        }
+      ],
+      initial: '',
+      inlineTags: [
+        {
+          format,
+          namepathOrURL,
+          tag,
+          text,
+          type: 'JsdocInlineTag'
+        }
+      ],
+      lineEnd: '',
+      name: '',
+      parsedType: null,
+      postDelimiter: '',
+      postName: '',
+      postTag: ' ',
+      postType: '',
+      rawType: '',
+      tag: 'see',
+      type: 'JsdocTag',
+      typeLines: []
+    }
+  ],
+  inlineTags: []
+});
 
 describe('commentParserToESTree', function () {
   it('handles single line jsdoc comment with tag', () => {
@@ -189,9 +290,11 @@ description`
                 initial: '',
                 type: 'JsdocTypeLine'
               }
-            ]
+            ],
+            inlineTags: []
           }
         ],
+        inlineTags: [],
         type: 'JsdocBlock'
       });
     }
@@ -261,9 +364,11 @@ description`
               initial: '',
               type: 'JsdocTypeLine'
             }
-          ]
+          ],
+          inlineTags: []
         }
-      ]
+      ],
+      inlineTags: []
     });
   });
 
@@ -315,9 +420,11 @@ description`
               initial: '',
               type: 'JsdocTypeLine'
             }
-          ]
+          ],
+          inlineTags: []
         }
-      ]
+      ],
+      inlineTags: []
     });
   });
 
@@ -369,9 +476,11 @@ description`
               initial: '',
               type: 'JsdocTypeLine'
             }
-          ]
+          ],
+          inlineTags: []
         }
-      ]
+      ],
+      inlineTags: []
     });
   });
 
@@ -498,9 +607,11 @@ description`
                 initial: ' ',
                 type: 'JsdocTypeLine'
               }
-            ]
+            ],
+            inlineTags: []
           }
         ],
+        inlineTags: [],
         type: 'JsdocBlock'
       });
     }
@@ -573,9 +684,11 @@ description`
                 initial: '',
                 type: 'JsdocTypeLine'
               }
-            ]
+            ],
+            inlineTags: []
           }
-        ]
+        ],
+        inlineTags: []
       });
     }
   );
@@ -611,6 +724,7 @@ description`
         lineEnd: '',
         postDelimiter: ' ',
         tags: [],
+        inlineTags: [],
         terminal: '*/'
       });
     }
@@ -655,6 +769,7 @@ description`
         lineEnd: '',
         postDelimiter: ' ',
         tags: [],
+        inlineTags: [],
         terminal: '*/'
       });
     }
@@ -709,7 +824,8 @@ description`
         lastDescriptionLine: 4,
         lineEnd: '',
         postDelimiter: '',
-        tags: []
+        tags: [],
+        inlineTags: []
       });
     }
   );
@@ -750,10 +866,44 @@ description`
           initial: ' ',
           tag: 'param',
           type: 'JsdocTag',
-          typeLines: []
+          typeLines: [],
+          inlineTags: []
         }
       ],
+      inlineTags: [],
       type: 'JsdocBlock'
     });
+  });
+
+  it('handles single line jsdoc comment with inline tag in description', () => {
+    const parsedComment = parseComment({
+      value: `* This is {@link Something}`
+    });
+
+    const ast = commentParserToESTree(parsedComment, 'jsdoc');
+
+    expect(ast).to.deep.equal(singleLineWithInlineTag({
+      description: 'This is {@link Something}',
+      text: '',
+      tag: 'link',
+      namepathOrURL: 'Something',
+      format: 'plain'
+    }));
+  });
+
+  it('handles single line jsdoc comment with inline tag in tag', () => {
+    const parsedComment = parseComment({
+      value: `* @see This is {@link Something}`
+    });
+
+    const ast = commentParserToESTree(parsedComment, 'jsdoc');
+
+    expect(ast).to.deep.equal(singleTagWithInlineTag({
+      description: 'This is {@link Something}',
+      text: '',
+      tag: 'link',
+      namepathOrURL: 'Something',
+      format: 'plain'
+    }));
   });
 });

--- a/test/parseComment.js
+++ b/test/parseComment.js
@@ -304,7 +304,7 @@ describe('parseComment', function () {
     });
   });
 
-  it('Handle plain inline type tag in description', function () {
+  it('Handle plain inline tag in description', function () {
     const parsed = parseComment({value: `* A link to {@link Something}`});
     expect(parsed).to.deep.equal({
       description: 'A link to {@link Something}',
@@ -343,7 +343,7 @@ describe('parseComment', function () {
     });
   });
 
-  it('Handle multiple inline type tags in multiline description', function () {
+  it('Handle multiple inline tags in multiline description', function () {
     const parsed = parseComment({
       value: `* A link to {@link Something}\n* and {@link SomethingElse}`
     });
@@ -410,7 +410,66 @@ describe('parseComment', function () {
     });
   });
 
-  it('Handle inline type tag with "spaced" text in description', function () {
+  it('Handle inline tags with multiline text', function () {
+    const parsed = parseComment({
+      value: `* A link to {@link Something|multiple\nlines}`
+    });
+    expect(parsed).to.deep.equal({
+      description: 'A link to {@link Something|multiple lines}',
+      tags: [],
+      inlineTags: [
+        {
+          tag: 'link',
+          namepathOrURL: 'Something',
+          text: 'multiple lines',
+          format: 'pipe',
+          start: 10,
+          end: 42
+        }
+      ],
+      source: [
+        {
+          number: 0,
+          source: '/** A link to {@link Something|multiple',
+          tokens: {
+            delimiter: '/**',
+            description: 'A link to {@link Something|multiple',
+            end: '',
+            lineEnd: '',
+            name: '',
+            postDelimiter: ' ',
+            postName: '',
+            postTag: '',
+            postType: '',
+            start: '',
+            tag: '',
+            type: ''
+          }
+        },
+        {
+          number: 1,
+          source: 'lines}*/',
+          tokens: {
+            delimiter: '',
+            description: 'lines}',
+            end: '*/',
+            lineEnd: '',
+            name: '',
+            postDelimiter: '',
+            postName: '',
+            postTag: '',
+            postType: '',
+            start: '',
+            tag: '',
+            type: ''
+          }
+        }
+      ],
+      problems: []
+    });
+  });
+
+  it('Handle inline tag with "spaced" text in description', function () {
     const parsed = parseComment({
       value: `* A link to {@link Something something awesome!}`
     });
@@ -451,7 +510,7 @@ describe('parseComment', function () {
     });
   });
 
-  it('Handle inline type tag with "piped" text in description', function () {
+  it('Handle inline tag with "piped" text in description', function () {
     const parsed = parseComment({
       value: `* A link to {@link Something|something awesome!}`
     });
@@ -492,7 +551,50 @@ describe('parseComment', function () {
     });
   });
 
-  it('Handle inline type tag with "prefixed" text in description', function () {
+  it('Handle inline tag with "piped" spaced text in description', function () {
+    const parsed = parseComment({
+      value: `* A link to {@link Something  |  something awesome!}`
+    });
+    expect(parsed).to.deep.equal({
+      description: 'A link to {@link Something  |  something awesome!}',
+      tags: [],
+      inlineTags: [
+        {
+          tag: 'link',
+          namepathOrURL: 'Something',
+          text: 'something awesome!',
+          format: 'pipe',
+          start: 10,
+          end: 50
+        }
+      ],
+      source: [
+        {
+          number: 0,
+          source:
+            '/** A link to {@link Something  |  something awesome!}*/',
+          tokens: {
+            delimiter: '/**',
+            description:
+              'A link to {@link Something  |  something awesome!}',
+            end: '*/',
+            lineEnd: '',
+            name: '',
+            postDelimiter: ' ',
+            postName: '',
+            postTag: '',
+            postType: '',
+            start: '',
+            tag: '',
+            type: ''
+          }
+        }
+      ],
+      problems: []
+    });
+  });
+
+  it('Handle inline tag with "prefixed" text in description', function () {
     const parsed = parseComment({
       value: `* A link to [something awesome!]{@link Something}`
     });
@@ -533,7 +635,7 @@ describe('parseComment', function () {
     });
   });
 
-  it('Handle plain inline type tag in tag', function () {
+  it('Handle plain inline tag in tag', function () {
     const parsed = parseComment({value: `* @see A link to {@link Something}`});
     expect(parsed).to.deep.equal({
       description: '',

--- a/test/parseComment.js
+++ b/test/parseComment.js
@@ -343,6 +343,73 @@ describe('parseComment', function () {
     });
   });
 
+  it('Handle multiple inline type tags in multiline description', function () {
+    const parsed = parseComment({
+      value: `* A link to {@link Something}\n* and {@link SomethingElse}`
+    });
+    expect(parsed).to.deep.equal({
+      description: 'A link to {@link Something} and {@link SomethingElse}',
+      tags: [],
+      inlineTags: [
+        {
+          tag: 'link',
+          namepathOrURL: 'Something',
+          text: '',
+          format: 'plain',
+          start: 10,
+          end: 27
+        },
+        {
+          tag: 'link',
+          namepathOrURL: 'SomethingElse',
+          text: '',
+          format: 'plain',
+          start: 32,
+          end: 53
+        }
+      ],
+      source: [
+        {
+          number: 0,
+          source: '/** A link to {@link Something}',
+          tokens: {
+            delimiter: '/**',
+            description: 'A link to {@link Something}',
+            end: '',
+            lineEnd: '',
+            name: '',
+            postDelimiter: ' ',
+            postName: '',
+            postTag: '',
+            postType: '',
+            start: '',
+            tag: '',
+            type: ''
+          }
+        },
+        {
+          number: 1,
+          source: '* and {@link SomethingElse}*/',
+          tokens: {
+            delimiter: '*',
+            description: 'and {@link SomethingElse}',
+            end: '*/',
+            lineEnd: '',
+            name: '',
+            postDelimiter: ' ',
+            postName: '',
+            postTag: '',
+            postType: '',
+            start: '',
+            tag: '',
+            type: ''
+          }
+        }
+      ],
+      problems: []
+    });
+  });
+
   it('Handle inline type tag with "spaced" text in description', function () {
     const parsed = parseComment({
       value: `* A link to {@link Something something awesome!}`

--- a/test/parseComment.js
+++ b/test/parseComment.js
@@ -12,6 +12,7 @@ describe('parseComment', function () {
           type: '',
           optional: false,
           description: '',
+          inlineTags: [],
           problems: [],
           source: [
             {
@@ -35,6 +36,7 @@ describe('parseComment', function () {
           ]
         }
       ],
+      inlineTags: [],
       source: [
         {
           number: 0,
@@ -70,6 +72,7 @@ describe('parseComment', function () {
           type: '',
           optional: true,
           description: '',
+          inlineTags: [],
           problems: [],
           source: [
             {
@@ -93,6 +96,7 @@ describe('parseComment', function () {
           ]
         }
       ],
+      inlineTags: [],
       source: [
         {
           number: 0,
@@ -130,6 +134,7 @@ describe('parseComment', function () {
           type: '',
           optional: false,
           description: '- Some description',
+          inlineTags: [],
           problems: [],
           source: [
             {
@@ -154,6 +159,7 @@ describe('parseComment', function () {
           ]
         }
       ],
+      inlineTags: [],
       source: [
         {
           number: 0,
@@ -189,6 +195,7 @@ describe('parseComment', function () {
           type: '',
           optional: false,
           description: '',
+          inlineTags: [],
           problems: [],
           source: [
             {
@@ -212,6 +219,7 @@ describe('parseComment', function () {
           ]
         }
       ],
+      inlineTags: [],
       source: [
         {
           number: 0,
@@ -247,6 +255,7 @@ describe('parseComment', function () {
           type: '',
           optional: false,
           description: 'SomeName',
+          inlineTags: [],
           problems: [],
           source: [
             {
@@ -270,6 +279,7 @@ describe('parseComment', function () {
           ]
         }
       ],
+      inlineTags: [],
       source: [
         {
           number: 0,
@@ -294,11 +304,243 @@ describe('parseComment', function () {
     });
   });
 
+  it('Handle plain inline type tag in description', function () {
+    const parsed = parseComment({value: `* A link to {@link Something}`});
+    expect(parsed).to.deep.equal({
+      description: 'A link to {@link Something}',
+      tags: [],
+      inlineTags: [
+        {
+          tag: 'link',
+          namepathOrURL: 'Something',
+          text: '',
+          textStyle: 'plain',
+          start: 10,
+          end: 27
+        }
+      ],
+      source: [
+        {
+          number: 0,
+          source: '/** A link to {@link Something}*/',
+          tokens: {
+            delimiter: '/**',
+            description: 'A link to {@link Something}',
+            end: '*/',
+            lineEnd: '',
+            name: '',
+            postDelimiter: ' ',
+            postName: '',
+            postTag: '',
+            postType: '',
+            start: '',
+            tag: '',
+            type: ''
+          }
+        }
+      ],
+      problems: []
+    });
+  });
+
+  it('Handle inline type tag with "spaced" text in description', function () {
+    const parsed = parseComment({
+      value: `* A link to {@link Something something awesome!}`
+    });
+    expect(parsed).to.deep.equal({
+      description: 'A link to {@link Something something awesome!}',
+      tags: [],
+      inlineTags: [
+        {
+          tag: 'link',
+          namepathOrURL: 'Something',
+          text: 'something awesome!',
+          textStyle: 'space',
+          start: 10,
+          end: 46
+        }
+      ],
+      source: [
+        {
+          number: 0,
+          source: '/** A link to {@link Something something awesome!}*/',
+          tokens: {
+            delimiter: '/**',
+            description: 'A link to {@link Something something awesome!}',
+            end: '*/',
+            lineEnd: '',
+            name: '',
+            postDelimiter: ' ',
+            postName: '',
+            postTag: '',
+            postType: '',
+            start: '',
+            tag: '',
+            type: ''
+          }
+        }
+      ],
+      problems: []
+    });
+  });
+
+  it('Handle inline type tag with "piped" text in description', function () {
+    const parsed = parseComment({
+      value: `* A link to {@link Something|something awesome!}`
+    });
+    expect(parsed).to.deep.equal({
+      description: 'A link to {@link Something|something awesome!}',
+      tags: [],
+      inlineTags: [
+        {
+          tag: 'link',
+          namepathOrURL: 'Something',
+          text: 'something awesome!',
+          textStyle: 'pipe',
+          start: 10,
+          end: 46
+        }
+      ],
+      source: [
+        {
+          number: 0,
+          source: '/** A link to {@link Something|something awesome!}*/',
+          tokens: {
+            delimiter: '/**',
+            description: 'A link to {@link Something|something awesome!}',
+            end: '*/',
+            lineEnd: '',
+            name: '',
+            postDelimiter: ' ',
+            postName: '',
+            postTag: '',
+            postType: '',
+            start: '',
+            tag: '',
+            type: ''
+          }
+        }
+      ],
+      problems: []
+    });
+  });
+
+  it('Handle inline type tag with "prefixed" text in description', function () {
+    const parsed = parseComment({
+      value: `* A link to [something awesome!]{@link Something}`
+    });
+    expect(parsed).to.deep.equal({
+      description: 'A link to [something awesome!]{@link Something}',
+      tags: [],
+      inlineTags: [
+        {
+          tag: 'link',
+          namepathOrURL: 'Something',
+          text: 'something awesome!',
+          textStyle: 'prefix',
+          start: 10,
+          end: 47
+        }
+      ],
+      source: [
+        {
+          number: 0,
+          source: '/** A link to [something awesome!]{@link Something}*/',
+          tokens: {
+            delimiter: '/**',
+            description: 'A link to [something awesome!]{@link Something}',
+            end: '*/',
+            lineEnd: '',
+            name: '',
+            postDelimiter: ' ',
+            postName: '',
+            postTag: '',
+            postType: '',
+            start: '',
+            tag: '',
+            type: ''
+          }
+        }
+      ],
+      problems: []
+    });
+  });
+
+  it('Handle plain inline type tag in tag', function () {
+    const parsed = parseComment({value: `* @see A link to {@link Something}`});
+    expect(parsed).to.deep.equal({
+      description: '',
+      tags: [
+        {
+          tag: 'see',
+          name: '',
+          type: '',
+          optional: false,
+          description: 'A link to {@link Something}',
+          problems: [],
+          inlineTags: [
+            {
+              tag: 'link',
+              namepathOrURL: 'Something',
+              text: '',
+              textStyle: 'plain',
+              start: 10,
+              end: 27
+            }
+          ],
+          source: [
+            {
+              number: 0,
+              source: '/** @see A link to {@link Something}*/',
+              tokens: {
+                delimiter: '/**',
+                description: 'A link to {@link Something}',
+                end: '*/',
+                lineEnd: '',
+                name: '',
+                postDelimiter: ' ',
+                postName: '',
+                postTag: ' ',
+                postType: '',
+                start: '',
+                tag: '@see',
+                type: ''
+              }
+            }
+          ]
+        }
+      ],
+      inlineTags: [],
+      source: [
+        {
+          number: 0,
+          source: '/** @see A link to {@link Something}*/',
+          tokens: {
+            delimiter: '/**',
+            description: 'A link to {@link Something}',
+            end: '*/',
+            lineEnd: '',
+            name: '',
+            postDelimiter: ' ',
+            postName: '',
+            postTag: ' ',
+            postType: '',
+            start: '',
+            tag: '@see',
+            type: ''
+          }
+        }
+      ],
+      problems: []
+    });
+  });
+
   it('Default to simple empty block (comment-parser issue #128)', function () {
     const parsed = parseComment({value: `* `});
     expect(parsed).to.deep.equal({
       description: '',
       tags: [],
+      inlineTags: [],
       source: [
         {
           number: 0,

--- a/test/parseComment.js
+++ b/test/parseComment.js
@@ -314,7 +314,7 @@ describe('parseComment', function () {
           tag: 'link',
           namepathOrURL: 'Something',
           text: '',
-          textStyle: 'plain',
+          format: 'plain',
           start: 10,
           end: 27
         }
@@ -355,7 +355,7 @@ describe('parseComment', function () {
           tag: 'link',
           namepathOrURL: 'Something',
           text: 'something awesome!',
-          textStyle: 'space',
+          format: 'space',
           start: 10,
           end: 46
         }
@@ -396,7 +396,7 @@ describe('parseComment', function () {
           tag: 'link',
           namepathOrURL: 'Something',
           text: 'something awesome!',
-          textStyle: 'pipe',
+          format: 'pipe',
           start: 10,
           end: 46
         }
@@ -437,7 +437,7 @@ describe('parseComment', function () {
           tag: 'link',
           namepathOrURL: 'Something',
           text: 'something awesome!',
-          textStyle: 'prefix',
+          format: 'prefix',
           start: 10,
           end: 47
         }
@@ -483,7 +483,7 @@ describe('parseComment', function () {
               tag: 'link',
               namepathOrURL: 'Something',
               text: '',
-              textStyle: 'plain',
+              format: 'plain',
               start: 10,
               end: 27
             }


### PR DESCRIPTION
This solves #11 by adding a second regexp based parse step on top of the `description` of a comment block as well as the `description` of any of the `tags` on a comment block.