### PR TITLE
fix: remove `@types/eslint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@types/eslint": "^9.6.1",
     "@types/estree": "^1.0.6",
     "@typescript-eslint/types": "^8.11.0",
     "comment-parser": "1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@types/eslint':
-        specifier: ^9.6.1
-        version: 9.6.1
       '@types/estree':
         specifier: ^1.0.6
         version: 1.0.6
@@ -1027,9 +1024,6 @@ packages:
 
   '@types/cytoscape@3.21.8':
     resolution: {integrity: sha512-6Bo9ZDrv0vfwe8Sg/ERc5VL0yU0gYvP4dgZi0fAXYkKHfyHaNqWRMcwYm3mu4sLsXbB8ZuXE75sR7qnaOL5JgQ==}
-
-  '@types/eslint@9.6.1':
-    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
   '@types/esquery@1.5.4':
     resolution: {integrity: sha512-yYO4Q8H+KJHKW1rEeSzHxcZi90durqYgWVfnh5K6ZADVBjBv2e1NEveYX5yT2bffgN7RqzH3k9930m+i2yBoMA==}
@@ -4350,11 +4344,6 @@ snapshots:
       tinyglobby: 0.2.9
 
   '@types/cytoscape@3.21.8': {}
-
-  '@types/eslint@9.6.1':
-    dependencies:
-      '@types/estree': 1.0.6
-      '@types/json-schema': 7.0.15
 
   '@types/esquery@1.5.4':
     dependencies:


### PR DESCRIPTION
ESLint now ships types by itself, so it's not necessary to add `@types/eslint` as a dependency anymore. 