### PR TITLE
fix: detect class method overload comments

### DIFF
--- a/dist/index.cjs.cjs
+++ b/dist/index.cjs.cjs
@@ -1025,6 +1025,53 @@ const overloadMethodNode = new Set(['MethodDefinition', 'TSAbstractMethodDefinit
 
 /**
  * @param {ESLintOrTSNode} node
+ * @returns {{
+ *   bodyless: boolean,
+ *   kind: string,
+ *   name: string,
+ *   static: boolean
+ * }|null}
+ */
+const getMethodOverloadInfo = node => {
+  if (!overloadMethodNode.has(node.type)) {
+    return null;
+  }
+
+  /**
+   * @type {{
+   *   computed?: boolean,
+   *   key?: {name?: string},
+   *   kind?: string,
+   *   static?: boolean,
+   *   value?: {type?: string}
+   * }}
+   */
+  // @ts-expect-error -- Loose method-shape check after node.type guard.
+  const method = node;
+  if (method.computed || method.kind !== 'method' || !method.key?.name) {
+    return null;
+  }
+  return {
+    bodyless: node.type === 'TSAbstractMethodDefinition' || method.value?.type === 'TSEmptyBodyFunctionExpression',
+    kind: method.kind,
+    name: method.key.name,
+    static: Boolean(method.static)
+  };
+};
+
+/**
+ * @param {ESLintOrTSNode} node
+ * @param {ESLintOrTSNode} prevSibling
+ * @returns {boolean}
+ */
+const isMatchingMethodOverloadSibling = (node, prevSibling) => {
+  const current = getMethodOverloadInfo(node);
+  const previous = getMethodOverloadInfo(prevSibling);
+  return Boolean(current && previous?.bodyless && previous.name === current.name && previous.kind === current.kind && previous.static === current.static);
+};
+
+/**
+ * @param {ESLintOrTSNode} node
  * @returns {string|undefined}
  */
 const getCurrentOverloadName = node => {
@@ -1120,7 +1167,7 @@ const getJSDocComment = function (sourceCode, node, settings, opts = {}) {
   if (!comment && opts.checkOverloads) {
     const functionName = getCurrentOverloadName(reducedNode);
     const prevSibling = getPreviousOverloadSibling(reducedNode);
-    if (prevSibling && functionName && getPreviousOverloadName(prevSibling) === functionName) {
+    if (prevSibling && functionName && getPreviousOverloadName(prevSibling) === functionName && (!overloadMethodNode.has(reducedNode.type) || isMatchingMethodOverloadSibling(reducedNode, prevSibling))) {
       return getJSDocComment(sourceCode, prevSibling, settings, opts);
     }
   }

--- a/dist/index.cjs.cjs
+++ b/dist/index.cjs.cjs
@@ -1021,12 +1021,91 @@ const findJSDocComment = (astNode, sourceCode, settings, opts = {}) => {
   }
   return null;
 };
+const overloadMethodNode = new Set(['MethodDefinition', 'TSAbstractMethodDefinition']);
+
+/**
+ * @param {ESLintOrTSNode} node
+ * @returns {string|undefined}
+ */
+const getCurrentOverloadName = node => {
+  if (node.type === 'TSDeclareFunction' || node.type === 'FunctionDeclaration') {
+    return /** @type {{id?: {name?: string}}} */node.id?.name;
+  }
+  if (node.type === 'ExportNamedDeclaration') {
+    const {
+      declaration
+    } = /** @type {{declaration?: {type?: string, id?: {name?: string}}}} */
+    node;
+    if (declaration?.type === 'FunctionDeclaration' || declaration?.type === 'TSDeclareFunction') {
+      return declaration.id?.name;
+    }
+  }
+  if (overloadMethodNode.has(node.type)) {
+    const method = /** @type {{computed?: boolean, key?: {name?: string}}} */node;
+    if (!method.computed) {
+      return method.key?.name;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * @param {ESLintOrTSNode} node
+ * @returns {string|undefined}
+ */
+const getPreviousOverloadName = node => {
+  if (node.type === 'TSDeclareFunction') {
+    return /** @type {{id?: {name?: string}}} */node.id?.name;
+  }
+  if (node.type === 'ExportNamedDeclaration') {
+    const {
+      declaration
+    } = /** @type {{declaration?: {type?: string, id?: {name?: string}}}} */
+    node;
+    if (declaration?.type === 'TSDeclareFunction') {
+      return declaration.id?.name;
+    }
+  }
+  if (overloadMethodNode.has(node.type)) {
+    const method = /** @type {{computed?: boolean, key?: {name?: string}}} */node;
+    if (!method.computed) {
+      return method.key?.name;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * @param {ESLintOrTSNode} node
+ * @returns {ESLintOrTSNode|null}
+ */
+const getPreviousOverloadSibling = node => {
+  const {
+    parent
+  } = node;
+  let childNode = node;
+  /** @type {ESLintOrTSNode[]|undefined} */
+  let siblings;
+  if (parent?.type === 'Program') {
+    siblings = /** @type {ESLintOrTSNode[]} */parent.body;
+  } else if (parent?.type === 'ExportNamedDeclaration' && parent.parent?.type === 'Program') {
+    childNode = parent;
+    siblings = /** @type {ESLintOrTSNode[]} */parent.parent.body;
+  } else if (overloadMethodNode.has(node.type) && parent?.type === 'ClassBody') {
+    siblings = /** @type {ESLintOrTSNode[]} */parent.body;
+  }
+  if (!siblings) {
+    return null;
+  }
+  const idx = siblings.indexOf(childNode);
+  return idx > 0 ? siblings[idx - 1] : null;
+};
 
 /**
  * Retrieves the JSDoc comment for a given node.
  *
  * @param {import('eslint').SourceCode} sourceCode The ESLint SourceCode
- * @param {import('eslint').Rule.Node} node The AST node to get
+ * @param {ESLintOrTSNode} node The AST node to get
  *   the comment for.
  * @param {Settings} settings The settings in context
  * @param {{checkOverloads?: boolean}} [opts]
@@ -1038,53 +1117,10 @@ const findJSDocComment = (astNode, sourceCode, settings, opts = {}) => {
 const getJSDocComment = function (sourceCode, node, settings, opts = {}) {
   const reducedNode = getReducedASTNode(node, sourceCode, settings);
   const comment = findJSDocComment(reducedNode, sourceCode, settings);
-  if (!comment && opts.checkOverloads && (reducedNode.parent?.type === 'Program' || reducedNode.parent?.type === 'ExportNamedDeclaration')) {
-    let functionName;
-    if (reducedNode.type === 'TSDeclareFunction' || reducedNode.type === 'FunctionDeclaration') {
-      functionName = reducedNode.id?.name;
-    } else if (reducedNode.type === 'ExportNamedDeclaration' && (reducedNode.declaration?.type === 'FunctionDeclaration' ||
-    // @ts-ignore Should be ok
-    reducedNode.declaration?.type === 'TSDeclareFunction')) {
-      functionName = reducedNode.declaration.id.name;
-    } else {
-      return null;
-    }
-
-    /**
-     * @type {import('estree').Program & {
-     *   parent: null
-     * }}
-     */
-    let programNode;
-
-    /**
-     * @type {ESLintOrTSNode}
-     */
-    let childNode;
-    if (reducedNode.parent?.type === 'Program') {
-      programNode = reducedNode.parent;
-      childNode = reducedNode;
-    } else if (reducedNode.parent?.parent.type === 'Program') {
-      programNode = reducedNode.parent.parent;
-      childNode = reducedNode.parent;
-      /* v8 ignore next 3 */
-    } else {
-      throw new Error('unexpected TS guard condition');
-    }
-
-    // @ts-expect-error Should be ok
-    const idx = programNode.body.indexOf(childNode);
-    const prevSibling = /** @type {import('eslint').AST.Program & {parent: null}} */programNode.body[idx - 1];
-    if (
-    // @ts-expect-error Should be ok
-    prevSibling?.type === 'TSDeclareFunction' &&
-    // @ts-expect-error Should be ok
-    functionName === prevSibling.id.name || prevSibling?.type === 'ExportNamedDeclaration' &&
-    // @ts-expect-error Should be ok
-    prevSibling.declaration?.type === 'TSDeclareFunction' &&
-    // @ts-expect-error Should be ok
-    prevSibling.declaration?.id?.name === functionName) {
-      // @ts-expect-error Should be ok
+  if (!comment && opts.checkOverloads) {
+    const functionName = getCurrentOverloadName(reducedNode);
+    const prevSibling = getPreviousOverloadSibling(reducedNode);
+    if (prevSibling && functionName && getPreviousOverloadName(prevSibling) === functionName) {
       return getJSDocComment(sourceCode, prevSibling, settings, opts);
     }
   }

--- a/dist/index.d.cts
+++ b/dist/index.d.cts
@@ -211,7 +211,7 @@ declare function getReducedASTNode(
  * Retrieves the JSDoc comment for a given node.
  *
  * @param {import('eslint').SourceCode} sourceCode The ESLint SourceCode
- * @param {import('eslint').Rule.Node} node The AST node to get
+ * @param {ESLintOrTSNode} node The AST node to get
  *   the comment for.
  * @param {Settings} settings The settings in context
  * @param {{checkOverloads?: boolean}} [opts]
@@ -222,7 +222,7 @@ declare function getReducedASTNode(
  */
 declare function getJSDocComment(
   sourceCode: eslint.SourceCode,
-  node: eslint.Rule.Node,
+  node: ESLintOrTSNode,
   settings: Settings,
   opts?: {
     checkOverloads?: boolean;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -211,7 +211,7 @@ declare function getReducedASTNode(
  * Retrieves the JSDoc comment for a given node.
  *
  * @param {import('eslint').SourceCode} sourceCode The ESLint SourceCode
- * @param {import('eslint').Rule.Node} node The AST node to get
+ * @param {ESLintOrTSNode} node The AST node to get
  *   the comment for.
  * @param {Settings} settings The settings in context
  * @param {{checkOverloads?: boolean}} [opts]
@@ -222,7 +222,7 @@ declare function getReducedASTNode(
  */
 declare function getJSDocComment(
   sourceCode: eslint.SourceCode,
-  node: eslint.Rule.Node,
+  node: ESLintOrTSNode,
   settings: Settings,
   opts?: {
     checkOverloads?: boolean;

--- a/src/jsdoccomment.js
+++ b/src/jsdoccomment.js
@@ -370,11 +370,111 @@ const findJSDocComment = (astNode, sourceCode, settings, opts = {}) => {
   return null;
 };
 
+const overloadMethodNode = new Set([
+  'MethodDefinition',
+  'TSAbstractMethodDefinition'
+]);
+
+/**
+ * @param {ESLintOrTSNode} node
+ * @returns {string|undefined}
+ */
+const getCurrentOverloadName = (node) => {
+  if (node.type === 'TSDeclareFunction' ||
+    node.type === 'FunctionDeclaration') {
+    return /** @type {{id?: {name?: string}}} */ (node).id?.name;
+  }
+
+  if (node.type === 'ExportNamedDeclaration') {
+    const {declaration} =
+      /** @type {{declaration?: {type?: string, id?: {name?: string}}}} */ (
+        node
+      );
+    if (declaration?.type === 'FunctionDeclaration' ||
+      declaration?.type === 'TSDeclareFunction') {
+      return declaration.id?.name;
+    }
+  }
+
+  if (overloadMethodNode.has(node.type)) {
+    const method =
+      /** @type {{computed?: boolean, key?: {name?: string}}} */ (node);
+    if (!method.computed) {
+      return method.key?.name;
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * @param {ESLintOrTSNode} node
+ * @returns {string|undefined}
+ */
+const getPreviousOverloadName = (node) => {
+  if (node.type === 'TSDeclareFunction') {
+    return /** @type {{id?: {name?: string}}} */ (node).id?.name;
+  }
+
+  if (node.type === 'ExportNamedDeclaration') {
+    const {declaration} =
+      /** @type {{declaration?: {type?: string, id?: {name?: string}}}} */ (
+        node
+      );
+    if (declaration?.type === 'TSDeclareFunction') {
+      return declaration.id?.name;
+    }
+  }
+
+  if (overloadMethodNode.has(node.type)) {
+    const method =
+      /** @type {{computed?: boolean, key?: {name?: string}}} */ (node);
+    if (!method.computed) {
+      return method.key?.name;
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * @param {ESLintOrTSNode} node
+ * @returns {ESLintOrTSNode|null}
+ */
+const getPreviousOverloadSibling = (node) => {
+  const {parent} = node;
+  let childNode = node;
+  /** @type {ESLintOrTSNode[]|undefined} */
+  let siblings;
+
+  if (parent?.type === 'Program') {
+    siblings = /** @type {ESLintOrTSNode[]} */ (parent.body);
+  } else if (
+    parent?.type === 'ExportNamedDeclaration' &&
+    parent.parent?.type === 'Program'
+  ) {
+    childNode = parent;
+    siblings = /** @type {ESLintOrTSNode[]} */ (parent.parent.body);
+  } else if (
+    overloadMethodNode.has(node.type) &&
+    parent?.type === 'ClassBody'
+  ) {
+    siblings = /** @type {ESLintOrTSNode[]} */ (parent.body);
+  }
+
+  if (!siblings) {
+    return null;
+  }
+
+  const idx = siblings.indexOf(childNode);
+  return idx > 0 ? siblings[idx - 1] : null;
+};
+
 /**
  * Retrieves the JSDoc comment for a given node.
  *
  * @param {import('eslint').SourceCode} sourceCode The ESLint SourceCode
- * @param {import('eslint').Rule.Node} node The AST node to get
+ * @param {ESLintOrTSNode} node The AST node to get
  *   the comment for.
  * @param {Settings} settings The settings in context
  * @param {{checkOverloads?: boolean}} [opts]
@@ -387,68 +487,14 @@ const getJSDocComment = function (sourceCode, node, settings, opts = {}) {
   const reducedNode = getReducedASTNode(node, sourceCode, settings);
   const comment = findJSDocComment(reducedNode, sourceCode, settings);
 
-  if (!comment &&
-    opts.checkOverloads &&
-    (
-      reducedNode.parent?.type === 'Program' ||
-      reducedNode.parent?.type === 'ExportNamedDeclaration'
-    )
-  ) {
-    let functionName;
-    if (reducedNode.type === 'TSDeclareFunction' ||
-      reducedNode.type === 'FunctionDeclaration') {
-      functionName = reducedNode.id?.name;
-    } else if (reducedNode.type === 'ExportNamedDeclaration' &&
-      (reducedNode.declaration?.type === 'FunctionDeclaration' ||
-      // @ts-ignore Should be ok
-      reducedNode.declaration?.type === 'TSDeclareFunction')
-    ) {
-      functionName = reducedNode.declaration.id.name;
-    } else {
-      return null;
-    }
-
-    /**
-     * @type {import('estree').Program & {
-     *   parent: null
-     * }}
-     */
-    let programNode;
-
-    /**
-     * @type {ESLintOrTSNode}
-     */
-    let childNode;
-
-    if (reducedNode.parent?.type === 'Program') {
-      programNode = reducedNode.parent;
-      childNode = reducedNode;
-    } else if (reducedNode.parent?.parent.type === 'Program') {
-      programNode = reducedNode.parent.parent;
-      childNode = reducedNode.parent;
-    /* v8 ignore next 3 */
-    } else {
-      throw new Error('unexpected TS guard condition');
-    }
-
-    // @ts-expect-error Should be ok
-    const idx = programNode.body.indexOf(childNode);
-    const prevSibling =
-      /** @type {import('eslint').AST.Program & {parent: null}} */ (
-        programNode
-      ).body[idx - 1];
+  if (!comment && opts.checkOverloads) {
+    const functionName = getCurrentOverloadName(reducedNode);
+    const prevSibling = getPreviousOverloadSibling(reducedNode);
     if (
-      // @ts-expect-error Should be ok
-      (prevSibling?.type === 'TSDeclareFunction' &&
-        // @ts-expect-error Should be ok
-        functionName === prevSibling.id.name) ||
-      (prevSibling?.type === 'ExportNamedDeclaration' &&
-        // @ts-expect-error Should be ok
-        prevSibling.declaration?.type === 'TSDeclareFunction' &&
-        // @ts-expect-error Should be ok
-        prevSibling.declaration?.id?.name === functionName)
+      prevSibling &&
+      functionName &&
+      getPreviousOverloadName(prevSibling) === functionName
     ) {
-      // @ts-expect-error Should be ok
       return getJSDocComment(sourceCode, prevSibling, settings, opts);
     }
   }

--- a/src/jsdoccomment.js
+++ b/src/jsdoccomment.js
@@ -377,6 +377,62 @@ const overloadMethodNode = new Set([
 
 /**
  * @param {ESLintOrTSNode} node
+ * @returns {{
+ *   bodyless: boolean,
+ *   kind: string,
+ *   name: string,
+ *   static: boolean
+ * }|null}
+ */
+const getMethodOverloadInfo = (node) => {
+  if (!overloadMethodNode.has(node.type)) {
+    return null;
+  }
+
+  /**
+   * @type {{
+   *   computed?: boolean,
+   *   key?: {name?: string},
+   *   kind?: string,
+   *   static?: boolean,
+   *   value?: {type?: string}
+   * }}
+   */
+  // @ts-expect-error -- Loose method-shape check after node.type guard.
+  const method = node;
+  if (method.computed || method.kind !== 'method' || !method.key?.name) {
+    return null;
+  }
+
+  return {
+    bodyless: node.type === 'TSAbstractMethodDefinition' ||
+      method.value?.type === 'TSEmptyBodyFunctionExpression',
+    kind: method.kind,
+    name: method.key.name,
+    static: Boolean(method.static)
+  };
+};
+
+/**
+ * @param {ESLintOrTSNode} node
+ * @param {ESLintOrTSNode} prevSibling
+ * @returns {boolean}
+ */
+const isMatchingMethodOverloadSibling = (node, prevSibling) => {
+  const current = getMethodOverloadInfo(node);
+  const previous = getMethodOverloadInfo(prevSibling);
+
+  return Boolean(
+    current &&
+    previous?.bodyless &&
+    previous.name === current.name &&
+    previous.kind === current.kind &&
+    previous.static === current.static
+  );
+};
+
+/**
+ * @param {ESLintOrTSNode} node
  * @returns {string|undefined}
  */
 const getCurrentOverloadName = (node) => {
@@ -493,7 +549,11 @@ const getJSDocComment = function (sourceCode, node, settings, opts = {}) {
     if (
       prevSibling &&
       functionName &&
-      getPreviousOverloadName(prevSibling) === functionName
+      getPreviousOverloadName(prevSibling) === functionName &&
+      (
+        !overloadMethodNode.has(reducedNode.type) ||
+        isMatchingMethodOverloadSibling(reducedNode, prevSibling)
+      )
     ) {
       return getJSDocComment(sourceCode, prevSibling, settings, opts);
     }

--- a/test/getJSDocComment.test.js
+++ b/test/getJSDocComment.test.js
@@ -209,6 +209,60 @@ describe('`getJSDocComment` overload comments', function () {
       expect(comment).to.equal(null);
     });
 
+  it('does not use a previous class method implementation comment',
+    function () {
+      const code = `
+        class Example {
+          /** Implementation docs */
+          value() {
+            return 1;
+          }
+          value() {
+            return 2;
+          }
+        }
+      `;
+      const {ast, sourceCode} = getTypeScriptSourceCode(code);
+      const method =
+        /** @type {TSClassDeclaration} */ (ast.body[0]).body.body[1];
+
+      const comment = getJSDocComment(
+        sourceCode,
+        /** @type {import('eslint').Rule.Node} */ (method),
+        overloadSettings,
+        {checkOverloads: true}
+      );
+
+      expect(comment).to.equal(null);
+    });
+
+  it('does not use getter comments for setter pairs',
+    function () {
+      const code = `
+        class Example {
+          /** Getter docs */
+          get value() {
+            return 1;
+          }
+          set value(input: number) {
+            this.internalValue = input;
+          }
+        }
+      `;
+      const {ast, sourceCode} = getTypeScriptSourceCode(code);
+      const setter =
+        /** @type {TSClassDeclaration} */ (ast.body[0]).body.body[1];
+
+      const comment = getJSDocComment(
+        sourceCode,
+        /** @type {import('eslint').Rule.Node} */ (setter),
+        overloadSettings,
+        {checkOverloads: true}
+      );
+
+      expect(comment).to.equal(null);
+    });
+
   it('still gets a function overload comment from a previous declaration',
     function () {
       const code = `

--- a/test/getJSDocComment.test.js
+++ b/test/getJSDocComment.test.js
@@ -1,5 +1,75 @@
-import {RuleTester} from 'eslint';
+import {RuleTester, SourceCode} from 'eslint';
+import {traverse} from 'estraverse';
+import typescriptEslintParser from 'typescript-eslint';
+import TSVisitorKeys from '@typescript-eslint/visitor-keys';
 import {getJSDocComment} from '../src/index.js';
+
+/**
+ * @typedef {import('@typescript-eslint/types').TSESTree.ClassDeclaration}
+ *   TSClassDeclaration
+ */
+
+/**
+ * @typedef {(code: string, options: Record<string, boolean>) => {
+ *   ast: import('eslint').AST.Program
+ * }} ParseTypeScriptForESLint
+ */
+const parseTypeScriptForESLint = /** @type {ParseTypeScriptForESLint} */ (
+  typescriptEslintParser.parser.parseForESLint
+);
+
+/**
+ * @param {string} code
+ * @returns {import('eslint').AST.Program}
+ */
+function parseTypeScriptAddingParents (code) {
+  const {ast} = parseTypeScriptForESLint(code, {
+    tokens: true,
+    comment: true,
+    loc: true,
+    range: true
+  });
+
+  const program = /** @type {import('eslint').AST.Program} */ (
+    ast
+  );
+
+  traverse(program, {
+    enter (node, parent) {
+      if (!node || !parent) {
+        return;
+      }
+
+      /** @type {import('estree').Node & {parent: import('estree').Node}} */ (
+        node
+      ).parent = parent;
+    },
+    keys: /** @type {Record<string, string[]>} */ (
+      TSVisitorKeys.visitorKeys
+    )
+  });
+  return program;
+}
+
+/**
+ * @param {string} code
+ * @returns {{
+ *   ast: import('eslint').AST.Program,
+ *   sourceCode: import('eslint').SourceCode
+ * }}
+ */
+function getTypeScriptSourceCode (code) {
+  const ast = parseTypeScriptAddingParents(code);
+  return {
+    ast,
+    sourceCode: new SourceCode(code, ast)
+  };
+}
+
+const overloadSettings = {
+  maxLines: 1,
+  minLines: 0
+};
 
 /**
  * @param {import('eslint').Rule.RuleContext} ctxt
@@ -65,6 +135,102 @@ const rule = {
 };
 
 const ruleTester = new RuleTester();
+
+describe('`getJSDocComment` overload comments', function () {
+  it('gets a class method overload comment from a previous overload',
+    function () {
+      const code = `
+        class Example {
+          /** Class overload docs */
+          value(input: string): string;
+          value(input: number): number;
+          value(input: string | number): string | number {
+            return input;
+          }
+        }
+      `;
+      const {ast, sourceCode} = getTypeScriptSourceCode(code);
+      const implementation =
+        /** @type {TSClassDeclaration} */ (ast.body[0]).body.body[2];
+
+      const comment = getJSDocComment(
+        sourceCode,
+        /** @type {import('eslint').Rule.Node} */ (implementation),
+        overloadSettings,
+        {checkOverloads: true}
+      );
+
+      expect(comment?.value).to.contain('Class overload docs');
+    });
+
+  it('gets an abstract method overload comment from a previous overload',
+    function () {
+      const code = `
+        abstract class Example {
+          /** Abstract overload docs */
+          abstract value(input: string): string;
+          abstract value(input: number): number;
+        }
+      `;
+      const {ast, sourceCode} = getTypeScriptSourceCode(code);
+      const overload =
+        /** @type {TSClassDeclaration} */ (ast.body[0]).body.body[1];
+
+      const comment = getJSDocComment(
+        sourceCode,
+        /** @type {import('eslint').Rule.Node} */ (overload),
+        overloadSettings,
+        {checkOverloads: true}
+      );
+
+      expect(comment?.value).to.contain('Abstract overload docs');
+    });
+
+  it('does not use a previous class method comment for a different name',
+    function () {
+      const code = `
+        class Example {
+          /** Other method docs */
+          value(input: string): string;
+          other(input: number): number;
+        }
+      `;
+      const {ast, sourceCode} = getTypeScriptSourceCode(code);
+      const method =
+        /** @type {TSClassDeclaration} */ (ast.body[0]).body.body[1];
+
+      const comment = getJSDocComment(
+        sourceCode,
+        /** @type {import('eslint').Rule.Node} */ (method),
+        overloadSettings,
+        {checkOverloads: true}
+      );
+
+      expect(comment).to.equal(null);
+    });
+
+  it('still gets a function overload comment from a previous declaration',
+    function () {
+      const code = `
+        /** Function overload docs */
+        function value(input: string): string;
+        function value(input: number): number;
+        function value(input: string | number): string | number {
+          return input;
+        }
+      `;
+      const {ast, sourceCode} = getTypeScriptSourceCode(code);
+
+      const comment = getJSDocComment(
+        sourceCode,
+        /** @type {import('eslint').Rule.Node} */ (ast.body[2]),
+        overloadSettings,
+        {checkOverloads: true}
+      );
+
+      expect(comment?.value).to.contain('Function overload docs');
+    });
+});
 
 ruleTester.run('getJSDocComment', rule, {
   invalid: [{

--- a/test/jsdoccomment.test.js
+++ b/test/jsdoccomment.test.js
@@ -22,6 +22,15 @@ const ESPREE_DEFAULT_CONFIG = {
 };
 
 /**
+ * @typedef {(code: string, options: Record<string, boolean>) => {
+ *   ast: import('eslint').AST.Program
+ * }} ParseTypeScriptForESLint
+ */
+const parseTypeScriptForESLint = /** @type {ParseTypeScriptForESLint} */ (
+  typescriptEslintParser.parser.parseForESLint
+);
+
+/**
  * @param {string} code
  * @param {{
  *   ecmaVersion: number,
@@ -38,7 +47,7 @@ function parseAddingParents (
 ) {
   const ast = parser === 'typescript'
     ? /** @type {import('eslint').AST.Program} */ (
-      typescriptEslintParser.parser.parseForESLint(code, {
+      parseTypeScriptForESLint(code, {
         tokens: true,
         comment: true,
         loc: true,


### PR DESCRIPTION
`getJSDocComment(..., { checkOverloads: true })` already walked preceding top-level function overloads, but class and abstract method overload signatures were not part of that lookup.

This keeps the existing overload option and extends it to adjacent noncomputed class-body method overload siblings, including `TSAbstractMethodDefinition`, so method implementation comments can resolve back to the overload JSDoc without changing the default `checkOverloads: false` path. I checked the focused overload test, full repo test suite, and explicit typecheck locally.

Refs gajus/eslint-plugin-jsdoc#1688
