### PR TITLE
fix: detect overload comments in nested scopes

### DIFF
--- a/dist/index.cjs.cjs
+++ b/dist/index.cjs.cjs
@@ -1022,6 +1022,18 @@ const findJSDocComment = (astNode, sourceCode, settings, opts = {}) => {
   return null;
 };
 const overloadMethodNode = new Set(['MethodDefinition', 'TSAbstractMethodDefinition']);
+const overloadStatementListNode = new Set(['BlockStatement', 'Program', 'StaticBlock', 'TSModuleBlock']);
+
+/**
+ * @param {ESLintOrTSNode|undefined} node
+ * @returns {ESLintOrTSNode[]|undefined}
+ */
+const getOverloadStatementSiblings = node => {
+  if (node && overloadStatementListNode.has(node.type)) {
+    return /** @type {ESLintOrTSNode[]} */node.body;
+  }
+  return undefined;
+};
 
 /**
  * @param {ESLintOrTSNode} node
@@ -1133,13 +1145,13 @@ const getPreviousOverloadSibling = node => {
   let childNode = node;
   /** @type {ESLintOrTSNode[]|undefined} */
   let siblings;
-  if (parent?.type === 'Program') {
+  if (overloadMethodNode.has(node.type) && parent?.type === 'ClassBody') {
     siblings = /** @type {ESLintOrTSNode[]} */parent.body;
-  } else if (parent?.type === 'ExportNamedDeclaration' && parent.parent?.type === 'Program') {
+  } else if (parent?.type === 'ExportNamedDeclaration') {
     childNode = parent;
-    siblings = /** @type {ESLintOrTSNode[]} */parent.parent.body;
-  } else if (overloadMethodNode.has(node.type) && parent?.type === 'ClassBody') {
-    siblings = /** @type {ESLintOrTSNode[]} */parent.body;
+    siblings = getOverloadStatementSiblings(parent.parent);
+  } else {
+    siblings = getOverloadStatementSiblings(parent);
   }
   if (!siblings) {
     return null;

--- a/src/jsdoccomment.js
+++ b/src/jsdoccomment.js
@@ -375,6 +375,25 @@ const overloadMethodNode = new Set([
   'TSAbstractMethodDefinition'
 ]);
 
+const overloadStatementListNode = new Set([
+  'BlockStatement',
+  'Program',
+  'StaticBlock',
+  'TSModuleBlock'
+]);
+
+/**
+ * @param {ESLintOrTSNode|undefined} node
+ * @returns {ESLintOrTSNode[]|undefined}
+ */
+const getOverloadStatementSiblings = (node) => {
+  if (node && overloadStatementListNode.has(node.type)) {
+    return /** @type {ESLintOrTSNode[]} */ (node.body);
+  }
+
+  return undefined;
+};
+
 /**
  * @param {ESLintOrTSNode} node
  * @returns {{
@@ -503,19 +522,16 @@ const getPreviousOverloadSibling = (node) => {
   /** @type {ESLintOrTSNode[]|undefined} */
   let siblings;
 
-  if (parent?.type === 'Program') {
-    siblings = /** @type {ESLintOrTSNode[]} */ (parent.body);
-  } else if (
-    parent?.type === 'ExportNamedDeclaration' &&
-    parent.parent?.type === 'Program'
-  ) {
-    childNode = parent;
-    siblings = /** @type {ESLintOrTSNode[]} */ (parent.parent.body);
-  } else if (
+  if (
     overloadMethodNode.has(node.type) &&
     parent?.type === 'ClassBody'
   ) {
     siblings = /** @type {ESLintOrTSNode[]} */ (parent.body);
+  } else if (parent?.type === 'ExportNamedDeclaration') {
+    childNode = parent;
+    siblings = getOverloadStatementSiblings(parent.parent);
+  } else {
+    siblings = getOverloadStatementSiblings(parent);
   }
 
   if (!siblings) {

--- a/test/getJSDocComment.test.js
+++ b/test/getJSDocComment.test.js
@@ -326,6 +326,30 @@ describe('`getJSDocComment` overload comments', function () {
       expect(comment?.value).to.contain('Nested function overload docs');
     });
 
+  it('does not check overload siblings without a statement-list parent',
+    function () {
+      const code = `
+        function value(input: string): string {
+          return input;
+        }
+      `;
+      const {ast, sourceCode} = getTypeScriptSourceCode(code);
+      const declaration = /** @type {TSFunctionDeclaration} */ (ast.body[0]);
+      const {parent} = declaration;
+      declaration.parent =
+        /** @type {TSFunctionDeclaration['parent']} */ (declaration.id);
+
+      const comment = getJSDocComment(
+        sourceCode,
+        /** @type {import('eslint').Rule.Node} */ (declaration),
+        overloadSettings,
+        {checkOverloads: true}
+      );
+
+      declaration.parent = parent;
+      expect(comment).to.equal(null);
+    });
+
   it('gets a static block function overload comment from a previous overload',
     function () {
       const code = `

--- a/test/getJSDocComment.test.js
+++ b/test/getJSDocComment.test.js
@@ -10,6 +10,21 @@ import {getJSDocComment} from '../src/index.js';
  */
 
 /**
+ * @typedef {import('@typescript-eslint/types').TSESTree.FunctionDeclaration}
+ *   TSFunctionDeclaration
+ */
+
+/**
+ * @typedef {import('@typescript-eslint/types').TSESTree.TSModuleDeclaration}
+ *   TSModuleDeclaration
+ */
+
+/**
+ * @typedef {import('@typescript-eslint/types').TSESTree.StaticBlock}
+ *   TSStaticBlock
+ */
+
+/**
  * @typedef {(code: string, options: Record<string, boolean>) => {
  *   ast: import('eslint').AST.Program
  * }} ParseTypeScriptForESLint
@@ -283,6 +298,194 @@ describe('`getJSDocComment` overload comments', function () {
       );
 
       expect(comment?.value).to.contain('Function overload docs');
+    });
+
+  it('gets a nested function overload comment from a previous overload',
+    function () {
+      const code = `
+        function outer() {
+          /** Nested function overload docs */
+          function value(input: string): string;
+          function value(input: number): number;
+          function value(input: string | number): string | number {
+            return input;
+          }
+        }
+      `;
+      const {ast, sourceCode} = getTypeScriptSourceCode(code);
+      const outer = /** @type {TSFunctionDeclaration} */ (ast.body[0]);
+      const implementation = outer.body.body[2];
+
+      const comment = getJSDocComment(
+        sourceCode,
+        /** @type {import('eslint').Rule.Node} */ (implementation),
+        overloadSettings,
+        {checkOverloads: true}
+      );
+
+      expect(comment?.value).to.contain('Nested function overload docs');
+    });
+
+  it('gets a static block function overload comment from a previous overload',
+    function () {
+      const code = `
+        class Example {
+          static {
+            /** Static block overload docs */
+            function value(input: string): string;
+            function value(input: number): number;
+            function value(input: string | number): string | number {
+              return input;
+            }
+          }
+        }
+      `;
+      const {ast, sourceCode} = getTypeScriptSourceCode(code);
+      const block =
+        /** @type {TSStaticBlock} */ (
+          /** @type {TSClassDeclaration} */ (ast.body[0]).body.body[0]
+        );
+      const implementation = block.body[2];
+
+      const comment = getJSDocComment(
+        sourceCode,
+        /** @type {import('eslint').Rule.Node} */ (implementation),
+        overloadSettings,
+        {checkOverloads: true}
+      );
+
+      expect(comment?.value).to.contain('Static block overload docs');
+    });
+
+  it('gets a namespace export overload comment from a previous overload',
+    function () {
+      const code = `
+        namespace Example {
+          /** Namespace overload docs */
+          export function value(input: string): string;
+          export function value(input: number): number;
+          export function value(input: string | number): string | number {
+            return input;
+          }
+        }
+      `;
+      const {ast, sourceCode} = getTypeScriptSourceCode(code);
+      const namespace = /** @type {TSModuleDeclaration} */ (ast.body[0]);
+      const implementation =
+        /** @type {{declaration: import('eslint').Rule.Node}} */ (
+          namespace.body.body[2]
+        ).declaration;
+
+      const comment = getJSDocComment(
+        sourceCode,
+        implementation,
+        overloadSettings,
+        {checkOverloads: true}
+      );
+
+      expect(comment?.value).to.contain('Namespace overload docs');
+    });
+
+  it('gets a nested class method overload comment from a previous overload',
+    function () {
+      const code = `
+        function outer() {
+          class Example {
+            /** Nested class overload docs */
+            value(input: string): string;
+            value(input: number): number;
+            value(input: string | number): string | number {
+              return input;
+            }
+          }
+        }
+      `;
+      const {ast, sourceCode} = getTypeScriptSourceCode(code);
+      const outer = /** @type {TSFunctionDeclaration} */ (ast.body[0]);
+      const classDeclaration =
+        /** @type {TSClassDeclaration} */ (outer.body.body[0]);
+      const implementation = classDeclaration.body.body[2];
+
+      const comment = getJSDocComment(
+        sourceCode,
+        /** @type {import('eslint').Rule.Node} */ (implementation),
+        overloadSettings,
+        {checkOverloads: true}
+      );
+
+      expect(comment?.value).to.contain('Nested class overload docs');
+    });
+
+  it('does not use a nested function overload comment for a different name',
+    function () {
+      const code = `
+        function outer() {
+          /** Nested function overload docs */
+          function value(input: string): string;
+          function other(input: number): number;
+        }
+      `;
+      const {ast, sourceCode} = getTypeScriptSourceCode(code);
+      const outer = /** @type {TSFunctionDeclaration} */ (ast.body[0]);
+      const overload = outer.body.body[1];
+
+      const comment = getJSDocComment(
+        sourceCode,
+        /** @type {import('eslint').Rule.Node} */ (overload),
+        overloadSettings,
+        {checkOverloads: true}
+      );
+
+      expect(comment).to.equal(null);
+    });
+
+  it('does not use a previous function implementation comment',
+    function () {
+      const code = `
+        function outer() {
+          /** Implementation docs */
+          function value(input: string): string {
+            return input;
+          }
+          function value(input: number): number;
+        }
+      `;
+      const {ast, sourceCode} = getTypeScriptSourceCode(code);
+      const outer = /** @type {TSFunctionDeclaration} */ (ast.body[0]);
+      const overload = outer.body.body[1];
+
+      const comment = getJSDocComment(
+        sourceCode,
+        /** @type {import('eslint').Rule.Node} */ (overload),
+        overloadSettings,
+        {checkOverloads: true}
+      );
+
+      expect(comment).to.equal(null);
+    });
+
+  it('does not use computed method overload comments',
+    function () {
+      const code = `
+        const key = 'value';
+        class Example {
+          /** Computed overload docs */
+          [key](input: string): string;
+          [key](input: number): number;
+        }
+      `;
+      const {ast, sourceCode} = getTypeScriptSourceCode(code);
+      const method =
+        /** @type {TSClassDeclaration} */ (ast.body[1]).body.body[1];
+
+      const comment = getJSDocComment(
+        sourceCode,
+        /** @type {import('eslint').Rule.Node} */ (method),
+        overloadSettings,
+        {checkOverloads: true}
+      );
+
+      expect(comment).to.equal(null);
     });
 });
 


### PR DESCRIPTION
`getJSDocComment(..., {checkOverloads: true})` followed overload comments for top-level functions and class methods, but a nested function overload never inherited the previous signature's comment inside a function body, static block, or TypeScript namespace. This widens the sibling lookup to those `BlockStatement`, `StaticBlock`, and `TSModuleBlock` bodies and unwraps `ExportNamedDeclaration` within them, while the class-method matching from #22 stays unchanged. I added focused tests for the nested cases and the negative controls; they and the existing overload suite pass. Refs gajus/eslint-plugin-jsdoc#1688.
