### PR TITLE
fix: honor \} and \] escapes in inline-tag labels

### DIFF
--- a/dist/index.cjs.cjs
+++ b/dist/index.cjs.cjs
@@ -44,6 +44,7 @@ const stripEncapsulatingBrackets = (container, isArr) => {
  */
 
 /**
+ * An inline tag whose `text` is the unescaped label value.
  * @typedef {{
  *   format: 'pipe' | 'plain' | 'prefix' | 'space',
  *   namepathOrURL: string,
@@ -508,6 +509,72 @@ const commentHandler = (settings, commentParserToESTreeOptions) => {
   };
 };
 
+/**
+ * @typedef {'pipe' | 'plain' | 'prefix' | 'space'} InlineTagFormat
+ */
+
+/**
+ * Gets the label delimiter for an inline-tag format.
+ * @param {InlineTagFormat} format
+ * @returns {string}
+ */
+function getLabelDelimiter(format) {
+  return format === 'prefix' ? ']' : '}';
+}
+
+/**
+ * Decodes context-specific escape pairs in an inline-tag label.
+ * @param {string} text
+ * @param {InlineTagFormat} format
+ * @returns {string}
+ */
+function decodeInlineTagText(text, format) {
+  const delimiter = getLabelDelimiter(format);
+  let decoded = '';
+  let idx = 0;
+  while (idx < text.length) {
+    const character = text[idx];
+    if (character === '\\') {
+      const nextCharacter = text[idx + 1];
+      if (nextCharacter === '\\' || nextCharacter === delimiter) {
+        decoded += nextCharacter;
+        idx += 2;
+        continue;
+      }
+    }
+    decoded += character;
+    idx++;
+  }
+  return decoded;
+}
+
+/**
+ * Minimally encodes an inline-tag label for its output context.
+ * @param {string} text
+ * @param {InlineTagFormat} format
+ * @returns {string}
+ */
+function encodeInlineTagText(text, format) {
+  const delimiter = getLabelDelimiter(format);
+  let encoded = '';
+  for (let idx = 0; idx < text.length; idx++) {
+    const character = text[idx];
+    if (character === delimiter) {
+      encoded += `\\${delimiter}`;
+      continue;
+    }
+    if (character === '\\') {
+      const nextCharacter = text[idx + 1];
+      if (nextCharacter === undefined || nextCharacter === '\\' || nextCharacter === delimiter) {
+        encoded += '\\\\';
+        continue;
+      }
+    }
+    encoded += character;
+  }
+  return encoded;
+}
+
 /* eslint-disable jsdoc/reject-function-type -- Different functions */
 /** @type {Record<string, Function>} */
 const stringifiers = {
@@ -546,9 +613,10 @@ const stringifiers = {
     tag,
     text
   }) {
-    return format === 'pipe' ? `{@${tag} ${namepathOrURL}|${text}}` : format === 'plain' ? `{@${tag} ${namepathOrURL}}` : format === 'prefix' ? `[${text}]{@${tag} ${namepathOrURL}}`
+    const encodedText = encodeInlineTagText(text, format);
+    return format === 'pipe' ? `{@${tag} ${namepathOrURL}|${encodedText}}` : format === 'plain' ? `{@${tag} ${namepathOrURL}}` : format === 'prefix' ? `[${encodedText}]{@${tag} ${namepathOrURL}}`
     // "space"
-    : `{@${tag} ${namepathOrURL} ${text}}`;
+    : `{@${tag} ${namepathOrURL} ${encodedText}}`;
   },
   JsdocTag
 };
@@ -1318,10 +1386,10 @@ function parseDescription(description) {
   // This could have been expressed in a single pattern,
   // but having two avoids a potentially exponential time regex.
 
-  const prefixedTextPattern = /(?:\[(?<text>[^\]]+)\])\{@(?<tag>[^\}\s]+)\s?(?<namepathOrURL>[^\}\s\|]*)\}/gvd;
+  const prefixedTextPattern = /(?:\[(?<text>(?:[^\\\]]|\\[\s\S])+)\])\{@(?<tag>[^\}\s]+)\s?(?<namepathOrURL>[^\}\s\|]*)\}/gvd;
   // The pattern used to match for text after tag uses a negative lookbehind
   // on the ']' char to avoid matching the prefixed case too.
-  const suffixedAfterPattern = /(?<!\])\{@(?<tag>[^\}\s]+)\s?(?<namepathOrURL>[^\}\s\|]*)\s*(?<separator>[\s\|])?\s*(?<text>[^\}]*)\}/gvd;
+  const suffixedAfterPattern = /(?<!\])\{@(?<tag>[^\}\s]+)\s?(?<namepathOrURL>[^\}\s\|]*)\s*(?<separator>[\s\|])?\s*(?<text>(?:[^\\\}]|\\[\s\S])*)\}/gvd;
   const matches = [...description.matchAll(prefixedTextPattern), ...description.matchAll(suffixedAfterPattern)];
   for (const mtch of matches) {
     const match =
@@ -1343,10 +1411,11 @@ function parseDescription(description) {
     } = match.groups;
     const [start, end] = match.indices[0];
     const format = determineFormat(match);
+    const decodedText = decodeInlineTagText(text, format);
     result.push({
       tag,
       namepathOrURL,
-      text,
+      text: decodedText,
       format,
       start,
       end

--- a/dist/index.d.cts
+++ b/dist/index.d.cts
@@ -20,6 +20,9 @@ type JsdocDescriptionLine = {
   initial: string;
   type: 'JsdocDescriptionLine';
 };
+/**
+ * An inline tag whose `text` is the unescaped label value.
+ */
 type JsdocInlineTagNoType = {
   format: 'pipe' | 'plain' | 'prefix' | 'space';
   namepathOrURL: string;
@@ -152,12 +155,7 @@ declare function commentHandler(
  */
 declare function estreeToString(
   node:
-    | JsdocBlock
-    | JsdocDescriptionLine
-    | JsdocTypeLine
-    | JsdocTag
-    | JsdocInlineTag
-    | jsdoc_type_pratt_parser.RootResult,
+    JsdocBlock | JsdocDescriptionLine | JsdocTypeLine | JsdocTag | JsdocInlineTag | jsdoc_type_pratt_parser.RootResult,
   opts?: ESTreeToStringOptions,
 ): string;
 
@@ -350,6 +348,9 @@ declare function parseComment(
  */
 declare function parseInlineTags(block: comment_parser.Block): JsdocBlockWithInline;
 
+/**
+ * An inline tag whose `text` is the unescaped label value.
+ */
 type InlineTag = JsdocInlineTagNoType & {
   start: number;
   end: number;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -20,6 +20,9 @@ type JsdocDescriptionLine = {
   initial: string;
   type: 'JsdocDescriptionLine';
 };
+/**
+ * An inline tag whose `text` is the unescaped label value.
+ */
 type JsdocInlineTagNoType = {
   format: 'pipe' | 'plain' | 'prefix' | 'space';
   namepathOrURL: string;
@@ -152,12 +155,7 @@ declare function commentHandler(
  */
 declare function estreeToString(
   node:
-    | JsdocBlock
-    | JsdocDescriptionLine
-    | JsdocTypeLine
-    | JsdocTag
-    | JsdocInlineTag
-    | jsdoc_type_pratt_parser.RootResult,
+    JsdocBlock | JsdocDescriptionLine | JsdocTypeLine | JsdocTag | JsdocInlineTag | jsdoc_type_pratt_parser.RootResult,
   opts?: ESTreeToStringOptions,
 ): string;
 
@@ -350,6 +348,9 @@ declare function parseComment(
  */
 declare function parseInlineTags(block: comment_parser.Block): JsdocBlockWithInline;
 
+/**
+ * An inline tag whose `text` is the unescaped label value.
+ */
 type InlineTag = JsdocInlineTagNoType & {
   start: number;
   end: number;

--- a/src/commentParserToESTree.js
+++ b/src/commentParserToESTree.js
@@ -49,6 +49,7 @@ const stripEncapsulatingBrackets = (container, isArr) => {
  */
 
 /**
+ * An inline tag whose `text` is the unescaped label value.
  * @typedef {{
  *   format: 'pipe' | 'plain' | 'prefix' | 'space',
  *   namepathOrURL: string,

--- a/src/estreeToString.js
+++ b/src/estreeToString.js
@@ -1,5 +1,7 @@
 import {stringify as prattStringify} from 'jsdoc-type-pratt-parser';
 
+import {encodeInlineTagText} from './inlineTagEscapes.js';
+
 /* eslint-disable jsdoc/reject-function-type -- Different functions */
 /** @type {Record<string, Function>} */
 const stringifiers = {
@@ -30,14 +32,15 @@ const stringifiers = {
    * @param {import('./commentParserToESTree').JsdocInlineTag} node
    */
   JsdocInlineTag ({format, namepathOrURL, tag, text}) {
+    const encodedText = encodeInlineTagText(text, format);
     return format === 'pipe'
-      ? `{@${tag} ${namepathOrURL}|${text}}`
+      ? `{@${tag} ${namepathOrURL}|${encodedText}}`
       : format === 'plain'
         ? `{@${tag} ${namepathOrURL}}`
         : format === 'prefix'
-          ? `[${text}]{@${tag} ${namepathOrURL}}`
+          ? `[${encodedText}]{@${tag} ${namepathOrURL}}`
           // "space"
-          : `{@${tag} ${namepathOrURL} ${text}}`;
+          : `{@${tag} ${namepathOrURL} ${encodedText}}`;
   },
 
   JsdocTag

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 /**
+ * An inline tag whose `text` is the unescaped label value.
  * @typedef {import('./commentParserToESTree').JsdocInlineTagNoType & {
  *   start: number,
  *   end: number,

--- a/src/inlineTagEscapes.js
+++ b/src/inlineTagEscapes.js
@@ -1,0 +1,75 @@
+/**
+ * @typedef {'pipe' | 'plain' | 'prefix' | 'space'} InlineTagFormat
+ */
+
+/**
+ * Gets the label delimiter for an inline-tag format.
+ * @param {InlineTagFormat} format
+ * @returns {string}
+ */
+function getLabelDelimiter (format) {
+  return format === 'prefix' ? ']' : '}';
+}
+
+/**
+ * Decodes context-specific escape pairs in an inline-tag label.
+ * @param {string} text
+ * @param {InlineTagFormat} format
+ * @returns {string}
+ */
+export function decodeInlineTagText (text, format) {
+  const delimiter = getLabelDelimiter(format);
+  let decoded = '';
+  let idx = 0;
+
+  while (idx < text.length) {
+    const character = text[idx];
+    if (character === '\\') {
+      const nextCharacter = text[idx + 1];
+      if (nextCharacter === '\\' || nextCharacter === delimiter) {
+        decoded += nextCharacter;
+        idx += 2;
+        continue;
+      }
+    }
+    decoded += character;
+    idx++;
+  }
+
+  return decoded;
+}
+
+/**
+ * Minimally encodes an inline-tag label for its output context.
+ * @param {string} text
+ * @param {InlineTagFormat} format
+ * @returns {string}
+ */
+export function encodeInlineTagText (text, format) {
+  const delimiter = getLabelDelimiter(format);
+  let encoded = '';
+
+  for (let idx = 0; idx < text.length; idx++) {
+    const character = text[idx];
+    if (character === delimiter) {
+      encoded += `\\${delimiter}`;
+      continue;
+    }
+
+    if (character === '\\') {
+      const nextCharacter = text[idx + 1];
+      if (
+        nextCharacter === undefined ||
+        nextCharacter === '\\' ||
+        nextCharacter === delimiter
+      ) {
+        encoded += '\\\\';
+        continue;
+      }
+    }
+
+    encoded += character;
+  }
+
+  return encoded;
+}

--- a/src/parseInlineTags.js
+++ b/src/parseInlineTags.js
@@ -1,3 +1,5 @@
+import {decodeInlineTagText} from './inlineTagEscapes.js';
+
 /**
  * @param {RegExpMatchArray & {
  *   indices: {
@@ -35,10 +37,10 @@ function parseDescription (description) {
   // This could have been expressed in a single pattern,
   // but having two avoids a potentially exponential time regex.
 
-  const prefixedTextPattern = /(?:\[(?<text>[^\]]+)\])\{@(?<tag>[^\}\s]+)\s?(?<namepathOrURL>[^\}\s\|]*)\}/gvd;
+  const prefixedTextPattern = /(?:\[(?<text>(?:[^\\\]]|\\[\s\S])+)\])\{@(?<tag>[^\}\s]+)\s?(?<namepathOrURL>[^\}\s\|]*)\}/gvd;
   // The pattern used to match for text after tag uses a negative lookbehind
   // on the ']' char to avoid matching the prefixed case too.
-  const suffixedAfterPattern = /(?<!\])\{@(?<tag>[^\}\s]+)\s?(?<namepathOrURL>[^\}\s\|]*)\s*(?<separator>[\s\|])?\s*(?<text>[^\}]*)\}/gvd;
+  const suffixedAfterPattern = /(?<!\])\{@(?<tag>[^\}\s]+)\s?(?<namepathOrURL>[^\}\s\|]*)\s*(?<separator>[\s\|])?\s*(?<text>(?:[^\\\}]|\\[\s\S])*)\}/gvd;
 
   const matches = [
     ...description.matchAll(prefixedTextPattern),
@@ -61,11 +63,12 @@ function parseDescription (description) {
     const {tag, namepathOrURL, text} = match.groups;
     const [start, end] = match.indices[0];
     const format = determineFormat(match);
+    const decodedText = decodeInlineTagText(text, format);
 
     result.push({
       tag,
       namepathOrURL,
-      text,
+      text: decodedText,
       format,
       start,
       end

--- a/test/estreeToString.test.js
+++ b/test/estreeToString.test.js
@@ -565,13 +565,14 @@ describe('`estreeToString`', function () {
     }
   });
 
-  it('documents A7 superfluous-backslash normalization', function () {
+  it('documents superfluous-backslash normalization', function () {
     const source = String.raw`{@link url|a\\b}`;
     const parsed = parseComment({value: `* ${source}`});
     const ast = commentParserToESTree(parsed, 'jsdoc');
     const [inlineTag] = ast.inlineTags;
 
-    // A7's one known exception: `\\` before a non-special byte normalizes.
+    // The one non-byte-identical round-trip class: a superfluous `\\`
+    // before a non-special byte normalizes to `\`.
     expect(inlineTag.text).to.equal(String.raw`a\b`);
     expect(estreeToString(inlineTag)).to.equal(String.raw`{@link url|a\b}`);
   });

--- a/test/estreeToString.test.js
+++ b/test/estreeToString.test.js
@@ -431,6 +431,151 @@ describe('`estreeToString`', function () {
     expect(str).to.equal('[something awesome!]{@link Something}');
   });
 
+  it('escapes a brace in a pipe inline-tag label', function () {
+    const str = estreeToString({
+      tag: 'link',
+      namepathOrURL: 'Something',
+      text: 'a}b',
+      format: 'pipe',
+      type: 'JsdocInlineTag'
+    });
+    expect(str).to.equal(String.raw`{@link Something|a\}b}`);
+  });
+
+  it('escapes a brace in a space inline-tag label', function () {
+    const str = estreeToString({
+      tag: 'link',
+      namepathOrURL: 'Something',
+      text: 'a}b',
+      format: 'space',
+      type: 'JsdocInlineTag'
+    });
+    expect(str).to.equal(String.raw`{@link Something a\}b}`);
+  });
+
+  it('escapes a bracket in a prefix inline-tag label', function () {
+    const str = estreeToString({
+      tag: 'link',
+      namepathOrURL: 'Something',
+      text: 'a]b',
+      format: 'prefix',
+      type: 'JsdocInlineTag'
+    });
+    expect(str).to.equal(String.raw`[a\]b]{@link Something}`);
+  });
+
+  it('escapes a trailing backslash in a pipe inline-tag label', function () {
+    const str = estreeToString({
+      tag: 'link',
+      namepathOrURL: 'Something',
+      text: 'a\\',
+      format: 'pipe',
+      type: 'JsdocInlineTag'
+    });
+    expect(str).to.equal(String.raw`{@link Something|a\\}`);
+  });
+
+  it('escapes a backslash followed by a brace in a pipe label', function () {
+    const str = estreeToString({
+      tag: 'link',
+      namepathOrURL: 'Something',
+      text: String.raw`a\}b`,
+      format: 'pipe',
+      type: 'JsdocInlineTag'
+    });
+    expect(str).to.equal(String.raw`{@link Something|a\\\}b}`);
+  });
+
+  it('does not gain an escape for an unescaped backslash', function () {
+    const str = estreeToString({
+      tag: 'link',
+      namepathOrURL: 'Something',
+      text: String.raw`a\b`,
+      format: 'pipe',
+      type: 'JsdocInlineTag'
+    });
+    expect(str).to.equal(String.raw`{@link Something|a\b}`);
+  });
+
+  it('does not escape a brace in a prefix inline-tag label', function () {
+    const str = estreeToString({
+      tag: 'link',
+      namepathOrURL: 'Something',
+      text: String.raw`a\}b`,
+      format: 'prefix',
+      type: 'JsdocInlineTag'
+    });
+    expect(str).to.equal(String.raw`[a\}b]{@link Something}`);
+  });
+
+  it('round-trips inline-tag label escapes with minimal encoding', function () {
+    const cases = [
+      {
+        source: String.raw`{@link url|a\}b}`,
+        text: 'a}b'
+      },
+      {
+        source: String.raw`[a\]b]{@link url}`,
+        text: 'a]b'
+      },
+      {
+        source: String.raw`{@link url|a\\}`,
+        text: 'a\\'
+      },
+      {
+        source: String.raw`{@link url|a\\\}b}`,
+        text: String.raw`a\}b`
+      },
+      {
+        source: String.raw`{@link url|a\\\b}`,
+        text: String.raw`a\\b`
+      },
+      {
+        source: String.raw`{@link url a\}b}`,
+        text: 'a}b'
+      },
+      {
+        source: String.raw`{@link url|a\b}`,
+        text: String.raw`a\b`
+      },
+      {
+        source: String.raw`{@link a\|b\|c}`,
+        text: String.raw`b\|c`
+      },
+      {
+        source: String.raw`[a\}b]{@link url}`,
+        text: String.raw`a\}b`
+      },
+      {
+        source: '{@link url}',
+        text: ''
+      }
+    ];
+
+    for (const {source, text} of cases) {
+      const parsed = parseComment({value: `* ${source}`});
+      const ast = commentParserToESTree(parsed, 'jsdoc');
+      const [inlineTag] = ast.inlineTags;
+      const parsedInlineTag =
+        /** @type {import('../src').InlineTag} */ (parsed.inlineTags[0]);
+      expect(inlineTag.text).to.equal(text);
+      expect(estreeToString(inlineTag)).to.equal(
+        parsed.description.slice(parsedInlineTag.start, parsedInlineTag.end)
+      );
+    }
+  });
+
+  it('documents A7 superfluous-backslash normalization', function () {
+    const source = String.raw`{@link url|a\\b}`;
+    const parsed = parseComment({value: `* ${source}`});
+    const ast = commentParserToESTree(parsed, 'jsdoc');
+    const [inlineTag] = ast.inlineTags;
+
+    // A7's one known exception: `\\` before a non-special byte normalizes.
+    expect(inlineTag.text).to.equal(String.raw`a\b`);
+    expect(estreeToString(inlineTag)).to.equal(String.raw`{@link url|a\b}`);
+  });
+
   it('throws upon encountering an unhandled node type', function () {
     expect(() => {
       /* eslint-disable jsdoc/reject-any-type -- Testing */

--- a/test/fixture/roundTripData.js
+++ b/test/fixture/roundTripData.js
@@ -538,6 +538,16 @@ compactResultsPratt.push(compactResults.at(-1));
 preserveResults.push(commentBlocks.at(-1));
 preserveResultsPratt.push(preserveResults.at(-1));
 
+// Escaped inline-tag label; block output deliberately preserves raw lines.
+
+commentBlocks.push(String.raw`/** This is {@link Something|a\}b} */`);
+
+compactResults.push(commentBlocks.at(-1));
+compactResultsPratt.push(compactResults.at(-1));
+
+preserveResults.push(commentBlocks.at(-1));
+preserveResultsPratt.push(preserveResults.at(-1));
+
 export {
   commentBlocks,
   compactResults,

--- a/test/parseComment.test.js
+++ b/test/parseComment.test.js
@@ -665,7 +665,7 @@ describe('parseComment (node)', function () {
     ]);
   });
 
-  it('Stops at a brace after an escaped backslash pair (A2)', function () {
+  it('Stops at a brace after an escaped backslash pair', function () {
     const description = String.raw`See {@link https://example.com|a\\}b}`;
     const matchedTag = String.raw`{@link https://example.com|a\\}`;
     const parsed = parseComment({value: `* ${description}`}, '');
@@ -681,7 +681,7 @@ describe('parseComment (node)', function () {
     ]);
   });
 
-  it('Requires an unescaped suffixed-label terminator (A3)', function () {
+  it('Requires an unescaped suffixed-label terminator', function () {
     // Back-compat delta: 0.88.0 parsed this as a truncated `text: 'a\\'`.
     const parsed = parseComment({
       value: String.raw`* See {@link url|a\}`
@@ -689,7 +689,7 @@ describe('parseComment (node)', function () {
     expect(parsed.inlineTags).to.deep.equal([]);
   });
 
-  it('Requires an unescaped prefix-label terminator (A3)', function () {
+  it('Requires an unescaped prefix-label terminator', function () {
     // Back-compat delta: 0.88.0 parsed this as a truncated `text: 'a\\'`.
     const parsed = parseComment({
       value: String.raw`* See [a\]{@link url}`
@@ -727,7 +727,7 @@ describe('parseComment (node)', function () {
     ]);
   });
 
-  it('Still stops at the first unescaped nested brace (A5)', function () {
+  it('Still stops at the first unescaped nested brace', function () {
     const description = 'See {@link url|a{b}c}';
     const matchedTag = '{@link url|a{b}';
     const parsed = parseComment({value: `* ${description}`}, '');
@@ -743,7 +743,7 @@ describe('parseComment (node)', function () {
     ]);
   });
 
-  it('Keeps escaped-bracket lookbehind limitation (A6)', function () {
+  it('Keeps escaped-bracket lookbehind limitation', function () {
     // Known limitation: the unchanged `(?<!\])` lookbehind rejects `\]{@`.
     const parsed = parseComment({
       value: String.raw`* See a\]{@link x}`
@@ -751,7 +751,7 @@ describe('parseComment (node)', function () {
     expect(parsed.inlineTags).to.deep.equal([]);
   });
 
-  it('Passes through backslash-pipe sequences (A8)', function () {
+  it('Passes through backslash-pipe sequences', function () {
     const inlineTag = String.raw`{@link a\|b\|c}`;
     const parsed = parseComment({value: `* See ${inlineTag}`}, '');
     expect(parsed.inlineTags).to.deep.equal([
@@ -766,7 +766,7 @@ describe('parseComment (node)', function () {
     ]);
   });
 
-  it('Leaves plain inline tags untouched (A9)', function () {
+  it('Leaves plain inline tags untouched', function () {
     const inlineTag = '{@link url}';
     const parsed = parseComment({value: `* See ${inlineTag}`}, '');
     expect(parsed.inlineTags).to.deep.equal([

--- a/test/parseComment.test.js
+++ b/test/parseComment.test.js
@@ -635,6 +635,169 @@ describe('parseComment (node)', function () {
     });
   });
 
+  it('Honors an escaped brace in a pipe label (#25 repro)', function () {
+    const inlineTag = String.raw`{@link https://example.com|a\}b}`;
+    const parsed = parseComment({value: `* See ${inlineTag}`}, '');
+    expect(parsed.inlineTags).to.deep.equal([
+      {
+        tag: 'link',
+        namepathOrURL: 'https://example.com',
+        text: 'a}b',
+        format: 'pipe',
+        start: 4,
+        end: 4 + inlineTag.length
+      }
+    ]);
+  });
+
+  it('Honors an escaped bracket in a prefix label (#25 repro)', function () {
+    const inlineTag = String.raw`[a\]b]{@link https://example.com}`;
+    const parsed = parseComment({value: `* See ${inlineTag}`}, '');
+    expect(parsed.inlineTags).to.deep.equal([
+      {
+        tag: 'link',
+        namepathOrURL: 'https://example.com',
+        text: 'a]b',
+        format: 'prefix',
+        start: 4,
+        end: 4 + inlineTag.length
+      }
+    ]);
+  });
+
+  it('Stops at a brace after an escaped backslash pair (A2)', function () {
+    const description = String.raw`See {@link https://example.com|a\\}b}`;
+    const matchedTag = String.raw`{@link https://example.com|a\\}`;
+    const parsed = parseComment({value: `* ${description}`}, '');
+    expect(parsed.inlineTags).to.deep.equal([
+      {
+        tag: 'link',
+        namepathOrURL: 'https://example.com',
+        text: 'a\\',
+        format: 'pipe',
+        start: 4,
+        end: 4 + matchedTag.length
+      }
+    ]);
+  });
+
+  it('Requires an unescaped suffixed-label terminator (A3)', function () {
+    // Back-compat delta: 0.88.0 parsed this as a truncated `text: 'a\\'`.
+    const parsed = parseComment({
+      value: String.raw`* See {@link url|a\}`
+    }, '');
+    expect(parsed.inlineTags).to.deep.equal([]);
+  });
+
+  it('Requires an unescaped prefix-label terminator (A3)', function () {
+    // Back-compat delta: 0.88.0 parsed this as a truncated `text: 'a\\'`.
+    const parsed = parseComment({
+      value: String.raw`* See [a\]{@link url}`
+    }, '');
+    expect(parsed.inlineTags).to.deep.equal([]);
+  });
+
+  it('Honors an escaped brace in a space label', function () {
+    const inlineTag = String.raw`{@link url a\}b}`;
+    const parsed = parseComment({value: `* See ${inlineTag}`}, '');
+    expect(parsed.inlineTags).to.deep.equal([
+      {
+        tag: 'link',
+        namepathOrURL: 'url',
+        text: 'a}b',
+        format: 'space',
+        start: 4,
+        end: 4 + inlineTag.length
+      }
+    ]);
+  });
+
+  it('Honors escaped labels in a tag description', function () {
+    const inlineTag = String.raw`{@link url|a\}b}`;
+    const parsed = parseComment({value: `* @see See ${inlineTag}`}, '');
+    expect(parsed.tags[0].inlineTags).to.deep.equal([
+      {
+        tag: 'link',
+        namepathOrURL: 'url',
+        text: 'a}b',
+        format: 'pipe',
+        start: 4,
+        end: 4 + inlineTag.length
+      }
+    ]);
+  });
+
+  it('Still stops at the first unescaped nested brace (A5)', function () {
+    const description = 'See {@link url|a{b}c}';
+    const matchedTag = '{@link url|a{b}';
+    const parsed = parseComment({value: `* ${description}`}, '');
+    expect(parsed.inlineTags).to.deep.equal([
+      {
+        tag: 'link',
+        namepathOrURL: 'url',
+        text: 'a{b',
+        format: 'pipe',
+        start: 4,
+        end: 4 + matchedTag.length
+      }
+    ]);
+  });
+
+  it('Keeps escaped-bracket lookbehind limitation (A6)', function () {
+    // Known limitation: the unchanged `(?<!\])` lookbehind rejects `\]{@`.
+    const parsed = parseComment({
+      value: String.raw`* See a\]{@link x}`
+    }, '');
+    expect(parsed.inlineTags).to.deep.equal([]);
+  });
+
+  it('Passes through backslash-pipe sequences (A8)', function () {
+    const inlineTag = String.raw`{@link a\|b\|c}`;
+    const parsed = parseComment({value: `* See ${inlineTag}`}, '');
+    expect(parsed.inlineTags).to.deep.equal([
+      {
+        tag: 'link',
+        namepathOrURL: 'a\\',
+        text: String.raw`b\|c`,
+        format: 'pipe',
+        start: 4,
+        end: 4 + inlineTag.length
+      }
+    ]);
+  });
+
+  it('Leaves plain inline tags untouched (A9)', function () {
+    const inlineTag = '{@link url}';
+    const parsed = parseComment({value: `* See ${inlineTag}`}, '');
+    expect(parsed.inlineTags).to.deep.equal([
+      {
+        tag: 'link',
+        namepathOrURL: 'url',
+        text: '',
+        format: 'plain',
+        start: 4,
+        end: 4 + inlineTag.length
+      }
+    ]);
+  });
+
+  it('Honors escapes in multiline labels', function () {
+    const parsed = parseComment({
+      value: String.raw`* See {@link url|a\}b
+* c}`
+    }, '');
+    expect(parsed.inlineTags).to.deep.equal([
+      {
+        tag: 'link',
+        namepathOrURL: 'url',
+        text: 'a}b c',
+        format: 'pipe',
+        start: 4,
+        end: parsed.description.length
+      }
+    ]);
+  });
+
   it('Handle plain inline tag in tag', function () {
     const parsed = parseComment({value: `* @see A link to {@link Something}`});
     expect(parsed).to.deep.equal({


### PR DESCRIPTION
Fixes #25.

Implements the design from your answer there: `text` on both surfaces (`parseComment(...).inlineTags` and the ESTree `JsdocInlineTag`) now carries the unescaped label value, and `estreeToString` re-encodes minimally on output.

Parser: the two inline-tag patterns accept escape pairs in labels (`(?:[^\\\]]|\\[\s\S])+` prefix, `(?:[^\\\}]|\\[\s\S])*` suffixed — disjoint first characters, so the two-pattern linear-time construction is preserved, as are the `gvd` flags, named groups, and raw offsets). A small internal codec (`src/inlineTagEscapes.js`, not exported) decodes context-specific pairs: `\]` and `\\` in prefix labels, `\}` and `\\` elsewhere. Any other backslash pair passes through untouched, so existing labels like `a\b` or `a\|b` are byte-identical before and after.

Stringifier: `JsdocInlineTag` output goes through a minimal encoder — the context delimiter is always escaped; a backslash is escaped only when followed by a backslash, the context delimiter, or end of text. Raw → parse → stringify is byte-identical across the covered property table.

Two deliberate behavior deltas, each pinned by a dedicated test — flagging both for your call:

1. A label whose only terminator is escaped no longer parses: `{@link url|a\}` and prefix `[a\]{@link url}` both parsed in 0.88.0 with truncated `text: 'a\\'`; an unescaped terminator is now required.
2. One many-to-one normalization: a superfluous `\\` before a non-special character round-trips to `\` (`{@link u|a\\b}` → `{@link u|a\b}`). Byte-perfect round-trip for every possible original is impossible once escape pairs decode at all (decoding is many-to-one), so the encoder is minimal-escape by design; this is the only non-identity class.

Tests: both #25 repros as named cases, escape/no-gain/round-trip tables across all four formats, plus pins for first-unescaped-brace termination and the existing `(?<!\])` lookbehind behavior. 207 passing, `tsc` clean; `dist/` rebuilt and committed per repo convention.

Follow-up once this is released: `eslint-plugin-jsdoc`'s `normalize-see-links` has four report-only / `output: null` expectations that exist only because `\}` / `\]` couldn't be emitted safely; those can flip to autofixes after a version bump here.
